### PR TITLE
Fix GitHub metadata in respecConfig

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,19 +38,8 @@
           wg:           "Internationalization Working Group",
           wgURI:        "https://www.w3.org/International/core/Overview",
           wgPublicList: "www-international",
-		  bugTracker: { new: "https://github.com/w3c/bp-i18n-specdev/issues", open: "https://github.com/w3c/bp-i18n-specdev/issues" } ,
-		otherLinks: [
-			{
-			key: "Github",
-			data: [
-				{
-			  	value: "repository",
-			  	href: "https://github.com/w3c/bp-i18n-specdev"
-		 		}
-				]
-			}
-			],
 
+          github: "w3c/bp-i18n-specdev",
 
           // URI of the patent status for this WG, for Rec-track documents
           // !!!! IMPORTANT !!!!


### PR DESCRIPTION
ReSpec now supports the `github` field directly:
https://github.com/w3c/respec/wiki/github


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/38.html" title="Last updated on Oct 31, 2019, 3:03 AM UTC (0f2f994)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/38/ff1c57d...0f2f994.html" title="Last updated on Oct 31, 2019, 3:03 AM UTC (0f2f994)">Diff</a>