### PR TITLE
Make the ruby section less HTML specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,7 +1448,8 @@
     <p class="advisement" id="type_ruby"><a class="self" href="#type_ruby">&#x200B;</a>'Ruby' style annotations alongside base text should be supported for Chinese, Japanese, Korean and Mongolian text, in both horizontal and vertical writing modes.</p>
     <p class="advisement" id="ruby_zhuyin"><a class="self" href="#ruby_zhuyin">&#x200B;</a>Ruby implementations should  support zhuyin fuhao (bopomofo) ruby for Traditional Chinese.</p>
     <p class="advisement" id="ruby_tabular"><a class="self" href="#ruby_tabular">&#x200B;</a>Ruby implementations should  support a tabular content model (such that ruby contents can be arranged in a sequence approximating to <code class="kw" translate="no">rb rb rt rt</code>).</p>
-    <p class="advisement" id="ruby_rb"><a class="self" href="#ruby_rb">&#x200B;</a>Ruby implementations should make it possible to use an explicit <code class="kw" translate="no">rb</code> tag for ruby bases.</p>
+    <p class="advisement" id="ruby_rb"><a class="self" href="#ruby_rb">&#x200B;</a>Ruby implementations should make it possible to use an explicit element for ruby bases, like the <code class="kw" translate="no">rb</code> element in HTML
+      .</p>
     <p class="advisement" id="ruby_dblsided"><a class="self" href="#ruby_dblsided">&#x200B;</a>Ruby implementations should allow annotations to appear on either or both sides of the base text.</p>
     <section class="links">
       <h4>Links</h4>

--- a/index.html
+++ b/index.html
@@ -1448,8 +1448,7 @@
     <p class="advisement" id="type_ruby"><a class="self" href="#type_ruby">&#x200B;</a>'Ruby' style annotations alongside base text should be supported for Chinese, Japanese, Korean and Mongolian text, in both horizontal and vertical writing modes.</p>
     <p class="advisement" id="ruby_zhuyin"><a class="self" href="#ruby_zhuyin">&#x200B;</a>Ruby implementations should  support zhuyin fuhao (bopomofo) ruby for Traditional Chinese.</p>
     <p class="advisement" id="ruby_tabular"><a class="self" href="#ruby_tabular">&#x200B;</a>Ruby implementations should  support a tabular content model (such that ruby contents can be arranged in a sequence approximating to <code class="kw" translate="no">rb rb rt rt</code>).</p>
-    <p class="advisement" id="ruby_rb"><a class="self" href="#ruby_rb">&#x200B;</a>Ruby implementations should make it possible to use an explicit element for ruby bases, like the <code class="kw" translate="no">rb</code> element in HTML
-      .</p>
+    <p class="advisement" id="ruby_rb"><a class="self" href="#ruby_rb">&#x200B;</a>Ruby implementations should make it possible to use an explicit element for ruby bases, like the <code class="kw" translate="no">rb</code> element in HTML.</p>
     <p class="advisement" id="ruby_dblsided"><a class="self" href="#ruby_dblsided">&#x200B;</a>Ruby implementations should allow annotations to appear on either or both sides of the base text.</p>
     <section class="links">
       <h4>Links</h4>


### PR DESCRIPTION
For example, TTML uses `<span tts:ruby="base">` as the ruby base element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/39.html" title="Last updated on Dec 20, 2019, 9:37 AM UTC (8eefb2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/39/bc875c6...8eefb2c.html" title="Last updated on Dec 20, 2019, 9:37 AM UTC (8eefb2c)">Diff</a>