### PR TITLE
I18N-ACTION-890: (for discussion in teleconference) health warning prototypes for normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1123,7 +1123,7 @@
     <section id="spec_n11n" class="subtopic">
 	<h4>Specifying Unicode Normalization</h4>
 	
-	<p class="advisement" id="text_n11n_specification"><a class="self" text="#text_n11n_specification">&#x200B;</a>Specifications that specify comparison or matching of strings SHOULD specify the appropriate note or warning regarding Unicode normalization.</p>
+	<p class="advisement" id="text_n11n_specification"><a class="self" text="#text_n11n_specification">&#x200B;</a>Specifications that perform comparison or matching of string values SHOULD specify the appropriate note or warning regarding Unicode normalization.</p>
     
     <p>The use or adoption of Unicode Normalization in a specification is usually part of defining how <a href="#string_match_steps">matching</a> takes place in a given format or protocol. To help specification authors and implementers understand some of the complexity involved, the Internationalization Working Group has developed a document describing the considerations for the matching and comparison of strings: <cite class="link"><a href="https://www.w3.org/TR/charmod-norm/">Character Model for the World Wide Web: String Matching</a></cite> [[CHARMOD-NORM]].</p>
     

--- a/index.html
+++ b/index.html
@@ -1122,10 +1122,12 @@
     
     <section id="spec_n11n" class="subtopic">
 	<h4>Specifying Unicode Normalization</h4>
+	
+	<p class="advisement" id="text_n11n_specification"><a class="self" text="#text_n11n_specification">&#x200B;</a>Specifications that specify comparison or matching of strings SHOULD specify the appropriate note or warning regarding Unicode normalization.</p>
     
     <p>The use or adoption of Unicode Normalization in a specification is usually part of defining how <a href="#string_match_steps">matching</a> takes place in a given format or protocol. To help specification authors and implementers understand some of the complexity involved, the Internationalization Working Group has developed a document describing the considerations for the matching and comparison of strings: <cite class="link"><a href="https://www.w3.org/TR/charmod-norm/">Character Model for the World Wide Web: String Matching</a></cite> [[CHARMOD-NORM]].</p>
     
-    <p>One of the choices specifications need to make is whether (or not) to require Unicode Normalization as part of matching various "values" defined as part of the specification's vocabulary. Values are commonly part of a document format or protocol's syntax, and include such things are attribute names or values; element names or values; IDs; and so forth. Specifications that follow the <a href="#text_n11n_default">recommendation</a> to <em>not</em> employ normalization as part of matching should include the following Note as a reminder to content authors.</p>
+    <p>One of the choices specifications need to make is whether (or not) to require Unicode Normalization as part of matching various "values" defined as part of the specification's vocabulary. Values are commonly part of a document format or protocol's syntax, and include such things as: attribute names or values, element names or values, IDs, and so forth. Specifications that follow the <a href="#text_n11n_default">recommendation</a> to <em>not</em> employ normalization as part of matching should include the following Note as a reminder to content authors.</p>
         
     <div class="example" id="n11n_note_figure">
 	   <p>Example note. Necessarily this version is non-specific about what constitutes "values": specifications may wish to be more specific.</p>

--- a/index.html
+++ b/index.html
@@ -1131,8 +1131,9 @@
         
     <div class="example" id="n11n_note_figure">
 	   <p>Example note. Necessarily this version is non-specific about what constitutes "values": specifications may wish to be more specific.</p>
-		    
-       <p class="note">This specification does not permit Unicode normalization of values for the purposes of comparison. Values that are visually and semantically identical but use different Unicode character sequences will not match. Content authors are advised to use the same encoding sequence consistently or to avoid potentially troublesome characters when choosing values. For more information, see [[CHARMOD-NORM]].</p>
+	   <div class="example_div">
+           <p class="note example_note">This specification does not permit Unicode normalization of values for the purposes of comparison. Values that are visually and semantically identical but use different Unicode character sequences will not match. Content authors are advised to use the same encoding sequence consistently or to avoid potentially troublesome characters when choosing values. For more information, see [[CHARMOD-NORM]].</p>
+       </div>
     </div>
     
     <p>Specifications that choose to require require normalization as part of string matching should include the following warning:</p>
@@ -1140,7 +1141,9 @@
     <div class="example" id="n11n_warning_figure">
      <p>Example warning. Necessarily this version is non-specific about what constitutes "values": specifications may wish to be more specific.</p>
      
-     <p class="warning">This specification applies Unicode normalization during the matching of values. This can have an effect on the appearance and meaning of the affected text. For more information, see [[CHARMOD-NORM]].</p> 
+       <div class="example_div">
+         <p class="warning">This specification applies Unicode normalization during the matching of values. This can have an effect on the appearance and meaning of the affected text. For more information, see [[CHARMOD-NORM]].</p> 
+       </div>
     </div>
     
     <p>Contact the I18N WG for alternatives or assistance if the above do not meet your needs or you're not sure about usage.</p>
@@ -1629,18 +1632,21 @@
 
 <p><a href="https://www.w3.org/TR/ltli/#localization">Localization</a> [[LTLI]] enables users to employ software in the language and locale of their choice. Specifications for protocols and document formats need to consider how to provide the language and formatting that the end-user expects.</p>
 
-<p class="advisement" id="l10n_api_message_id">APIs and protocols SHOULD provide language independent identifiers for errors. For example, HTTP result codes, such as the familiar <code>404</code> help users communicate which error they received or look up a translation.</p>
+<p class="advisement" id="l10n_api_message_id">APIs and protocols SHOULD provide language independent identifiers for errors.</p>
 
-<p class="advisement" id="l10n_api_error_message_metadata">APIs and protocols SHOULD include language and direction metadata for all natural language messages, including errors, to ensure proper presentation, even if localization is not provided. See also [[STRING-META]].</p>
+<p>For example, HTTP result codes, such as the familiar <code>404</code>, help users communicate which error they received or look up a translation.</p>
+
+<p class="advisement" id="l10n_api_error_message_metadata">APIs and protocols SHOULD include language and base direction metadata for all natural language messages and data fields.</p>
+
+<p>Natural language data values need language and base direction in order to ensure proper presentation, even if localized messages are not provided. This includes any error messages or other internal messages that are human readable in an API or protocol. See also [[STRING-META]].</p>
 
 <p class="advisement" id="l10n_api_error_message_language">All natural language fields or messages, including error messages, defined by a given API or protocol SHOULD be localized into the preferred locale of the user or, if that language is not available, supplied with a suitable fallback or default.</p>
 
-<p class="advisement" id="l10n_api_lang_nego">Specifications for APIs or protocols SHOULD define how the user's locale is determined (this is called <a href="#lang_negotiation">language negotiation</a>).</p>
+<p class="advisement" id="l10n_api_lang_nego">Specifications for APIs or protocols SHOULD define how the user's locale is determined (this is sometimes called <a href="#lang_negotiation">language negotiation</a>).</p>
 
 <p class="advisement" id="l10n_api_lang_defaulting">Specifications MAY define a specific default language for messages or errors in an API or protocol.</p>
 
-<p>Note that specifications do not need to require that messages be returned in all possible or all available locales.</p>
-
+<p class="note">Specifications do not need to require that messages be returned in all possible or all available locales. It is sufficient to make it possible to localize the end-user's customer experience. Implementations can choose which languages or locales to support.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@
 
 <p class="advisement" id="l10n_api_message_id">APIs and protocols SHOULD provide language independent identifiers for errors. For example, HTTP result codes, such as the familiar <code>404</code> help users communicate which error they received or look up a translation.</p>
 
-<p class="advisement" id="l10n_api_error_message_metadata">APIs and protocols SHOULD include language and direction metadata for all natural language messages, including errors, to ensure proper presentation, even if localization is not provided. See also [[STRING-META]]</p>
+<p class="advisement" id="l10n_api_error_message_metadata">APIs and protocols SHOULD include language and direction metadata for all natural language messages, including errors, to ensure proper presentation, even if localization is not provided. See also [[STRING-META]].</p>
 
 <p class="advisement" id="l10n_api_error_message_language">All natural language fields or messages, including error messages, defined by a given API or protocol SHOULD be localized into the preferred locale of the user or, if that language is not available, supplied with a suitable fallback or default.</p>
 

--- a/index.html
+++ b/index.html
@@ -1625,6 +1625,25 @@
 <p class="advisement" id="loc_numbers_shape_display"><a class="self" href="#loc_numbers_shape_display">&#x200B;</a>When formatting numeric values for display, allow for culturally sensitive display, including the use of non-ASCII digits (digit shaping).</p>
 </section>
 
+<section id="localization" class="subtopic"><h3>Localization</h3>
+
+<p><a href="https://www.w3.org/TR/ltli/#localization">Localization</a> [[LTLI]] enables users to employ software in the language and locale of their choice. Specifications for protocols and document formats need to consider how to provide the language and formatting that the end-user expects.</p>
+
+<p class="advisement" id="l10n_api_message_id">APIs and protocols SHOULD provide language independent identifiers for errors. For example, HTTP result codes, such as the familiar <code>404</code> help users communicate which error they received or look up a translation.</p>
+
+<p class="advisement" id="l10n_api_error_message_metadata">APIs and protocols SHOULD include language and direction metadata for all natural language messages, including errors, to ensure proper presentation, even if localization is not provided. See also [[STRING-META]]</p>
+
+<p class="advisement" id="l10n_api_error_message_language">All natural language fields or messages, including error messages, defined by a given API or protocol SHOULD be localized into the preferred locale of the user or, if that language is not available, supplied with a suitable fallback or default.</p>
+
+<p class="advisement" id="l10n_api_lang_nego">Specifications for APIs or protocols SHOULD define how the user's locale is determined (this is called <a href="#lang_negotiation">language negotiation</a>).</p>
+
+<p class="advisement" id="l10n_api_lang_defaulting">Specifications MAY define a specific default language for messages or errors in an API or protocol.</p>
+
+<p>Note that specifications do not need to require that messages be returned in all possible or all available locales.</p>
+
+
+</section>
+
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -1102,7 +1102,8 @@
   
   <section id="text_n11n" class="subtopic">
     <h3>Working with  Unicode Normalization</h3>
-	    <p class="advisement" id="text_n11n_default"><a class="self" href="#text_n11n_default">&#x200B;</a>Specifications SHOULD NOT specify a Unicode normalization form for encoding, storage, or interchange of a given vocabulary. <a href="https://www.w3.org/TR/charmod-norm/#normalizationChoice">more</a></p>
+
+	<p class="advisement" id="text_n11n_default"><a class="self" href="#text_n11n_default">&#x200B;</a>Specifications SHOULD NOT specify a Unicode normalization form for encoding, storage, or interchange of a given vocabulary. <a href="https://www.w3.org/TR/charmod-norm/#normalizationChoice">more</a></p>
 		
     <p class="advisement" id="text_n11n_no_change"><a class="self" href="#text_n11n_no_change">&#x200B;</a>Implementations MUST NOT alter the normalization form of syntactic or natural language content being exchanged, read, parsed, or processed except when required to do so as a side-effect of text transformation such as transcoding the content to a Unicode character encoding, case folding, or other user-initiated change, as consumers or the content itself might depend on the de-normalized representation. <a href="https://www.w3.org/TR/charmod-norm/#normalizationChoice">more</a></p>
 	
@@ -1116,7 +1117,28 @@
 	
     <p class="advisement" id="text_n11n_sensitive_operations"><a class="self" href="#text_n11n_sensitive_operations">&#x200B;</a>Normalization-sensitive operations MUST NOT be performed unless the implementation has first either confirmed through inspection that the text is in normalized form or it has re-normalized the text itself. Private agreements MAY be created within private systems which are not subject to these rules, but any externally observable results MUST be the same as if the rules had been obeyed. <a href="https://www.w3.org/TR/charmod-norm/#normalizing-spec">more</a></p>
 	
-<p class="advisement" id="text_n11n_mechanism"><a class="self" href="#text_n11n_mechanism">&#x200B;</a>A normalizing text-processing component which modifies text and performs normalization-sensitive operations MUST behave as if normalization took place after each modification, so that any subsequent normalization-sensitive operations always behave as if they were dealing with normalized text. <a href="https://www.w3.org/TR/charmod-norm/#normalizing-spec">more</a></p>
+    <p class="advisement" id="text_n11n_mechanism"><a class="self" href="#text_n11n_mechanism">&#x200B;</a>A normalizing text-processing component which modifies text and performs normalization-sensitive operations MUST behave as if normalization took place after each modification, so that any subsequent normalization-sensitive operations always behave as if they were dealing with normalized text. <a href="https://www.w3.org/TR/charmod-norm/#normalizing-spec">more</a></p>
+    
+    <section id="spec_n11n" class="subtopic">
+	<h4>Specifying Unicode Normalization and health warnings</h4>
+    
+    <p>Unicode Normaliztion and its use or adoption in Specifications is a complex topic. The Internationalization Working Group has developed a document describing the considerations for the matching and comparison of strings <cite class="link"><a href="https://www.w3.org/TR/charmod-norm/">Character Model for the World Wide Web: String Matching</a></cite> [[CHARMOD-NORM]].</p>
+    
+    <p>Specifications sometimes find it necessary to include health warnings related to Unicode normalization. Following are prototypes for different health warnings recommended by I18N.</p>
+    
+    <p>For specifications that do not permit normalization, we suggest the following health warning. Note that this version is necessarily non-specific about "values"; specification authors might wish to be more specific about the fields, attributes, or elements that are affected.</p>
+    
+    <p class="note">This specification does not permit Unicode normalization of values for the purposes of comparison. Values that are visually and semantically identical but use different Unicode character sequences will not match. Content authors are advised to use the same encoding sequence consistently or to avoid potentially troublesome characters when choosing values. For more information, see [[CHARMOD-NORM]].</p>
+    
+    <p>For specifications that require normalization as part of string matching (such as when matching IDs or user-defined tokens):</p>
+    
+     <p class="warning">This specification applies Unicode normalization during the matching of values. This can have an effect on the appearance and meaning of the affected text. For more information, see [[CHARMOD-NORM]].</p> 
+    
+    <p>Contact the I18N WG for alternatives or assistance if the above do not meet your needs or you're not sure about usage.</p>
+    
+  </section>
+    
+    
 <section class="links">
   <h4>Links</h4>
       <section class="background">

--- a/local.css
+++ b/local.css
@@ -241,3 +241,10 @@ table.truncExample kbd,code {
 .summary .secno {
 	display: none;
 	}
+	
+.example_div {
+    margin-left: 4em;
+    margin-right: 4em;
+    font-size: 90%;
+	}
+


### PR DESCRIPTION
Added a proposed set of health warnings pertaining to Unicode normalization.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/41.html" title="Last updated on Aug 15, 2020, 8:41 PM UTC (e469f11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/41/cdbf6d5...aphillips:e469f11.html" title="Last updated on Aug 15, 2020, 8:41 PM UTC (e469f11)">Diff</a>