### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script async src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script async src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -35,18 +35,10 @@
           ],
 
 
-          wg:           "Internationalization Working Group",
-          wgURI:        "https://www.w3.org/International/core/",
+          group:        "i18n",
           wgPublicList: "www-international",
 
           github: "w3c/bp-i18n-specdev",
-
-          // URI of the patent status for this WG, for Rec-track documents
-          // !!!! IMPORTANT !!!!
-          // This is important for Rec-track documents, do not copy a patent URI from a random
-          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-          // Team Contact.
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
 		  maxTocLevel: 2,
       };
     </script>


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/46.html" title="Last updated on Jul 22, 2020, 3:02 AM UTC (1a700fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/46/cdbf6d5...1a700fe.html" title="Last updated on Jul 22, 2020, 3:02 AM UTC (1a700fe)">Diff</a>