### PR TITLE
Make the ruby section less HTML specific (2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2325,7 +2325,7 @@
 	</div>
 
    	<div class="req" id="ruby_rb">
-	<p class="advisement">Ruby implementations should make it possible to use an explicit <code class="kw" translate="no">rb</code> tag for ruby bases.</p>
+	<p class="advisement">Ruby implementations should make it possible to use an explicit element for ruby bases, like the <code class="kw" translate="no">rb</code> element in HTML.</p>
 	</div>
 
    	<div class="req" id="ruby_dblsided">


### PR DESCRIPTION
This PR applies Fuqiao's PR at https://github.com/w3c/bp-i18n-specdev/pull/39 to the newly refactored markup.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/51.html" title="Last updated on Mar 11, 2021, 4:34 PM UTC (f025cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/51/cc0d818...f025cce.html" title="Last updated on Mar 11, 2021, 4:34 PM UTC (f025cce)">Diff</a>