### PR TITLE
Add text for stock health warning about selection/truncation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1986,6 +1986,20 @@
 	<p class="advisement">If a specification sets a length limit in code units (such as bytes), it MUST specify that truncation can only occur on code point boundaries.</p>
 	</div>
 
+	
+	<p>Note that this best practice applies equally to specifications based on UTF-16, which uses 16-bit code units, not just to multibyte encodings such as UTF-8.</p>
+    	<p>Specifications or APIs that interact with the [[DOM]] need to contend with the fact that character data, including operations such as <kbd>length</kbd>, <kbd>substringData</kbd>, <kbd>insertData</kbd>, <kbd>deleteData</kbd>, and so forth, is specified using UTF-16 code units, not Unicode code points. This can lead to inappropriate mid-character (code point) truncation. Specifications that reference DOM should specify that string operations not occur inside code points, and, where appropriate avoid starting or ending inside grapheme boundaries. Specifications should also include a health warning for implementers and users.</p>
+    	<div class=example>
+		<p>Example warning. Modify this health warning as appropriate for your specification:</p>
+		<div class="example_div">
+		<p class="warning">Arbitrary index values in the DOM may not fall on character or grapheme boundaries. Implementations and users should avoid incorrectly starting or ending operations in the middle of a user-perceived character sequence.</p>
+		</div>
+    	</div>
+
+	<div class="req" id="char_trunc_grapheme_boundary">
+	<p class="advisement">Specifications that limit the length of a string SHOULD require truncation on grapheme boundaries, as truncation in the midst of a combining or joining sequence can alter the meaning of the string.</p>
+	</div>
+
 	<div class="req" id="char_trunc_indicator">
 	<p class="advisement">If a specification specifies a length limit, it SHOULD specify that any string that is truncated include an indicator, such as ellipses, that the string has been altered.</p>
 	</div>


### PR DESCRIPTION
This PR applies Addison's PR at #50 to avoid conflicts with the newly refactored markup.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/53.html" title="Last updated on Mar 11, 2021, 5:06 PM UTC (7be90a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/53/0dabbca...7be90a6.html" title="Last updated on Mar 11, 2021, 5:06 PM UTC (7be90a6)">Diff</a>