### PR TITLE
Add correct string recommendations [I18N-ACTION-1216]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1713,6 +1713,24 @@ just as characters are the basic unit of organization of encoded text.</p>
 <p>[[[#char_def]]].</p>
 </div>
 
+<p>Specifications need to be clear about the encoding and processing of textual data. The recommendations in this section are mutually consistent with those in [[DESIGN-PRINCIPLES]]. In general, specifications should only support well-formed Unicode code point strings and should avoid the use of (or access to) the underlying code units or the use of different character encodings.</p>
+
+<div class="req" id="char_string_char">
+	<p class="advisement">Specifications SHOULD define strings as a sequence of <a>Unicode code points</a>.</p>
+	<details class="links"><summary>explanations &amp; examples</summary>
+	   <p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C012</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
+	</details>
+</div>
+
+<div class="req" id="char_string_domstring">
+	<p class="advisement">When designing a web platform feature which operates on strings, use <a href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a> unless you have a specific reason not to.</p>
+</div>
+
+<aside class="note">
+	<p>The type <code>DOMString</code> is actually a UTF-16 <a>code unit</a> string. This type allows unpaired <a>surrogate</a> code units to appear in a string, which can result in errors or replacement with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi> [<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>)</p>
+</aside>
+
+
 <div class="req" id="char_string_byte">
 	<p class="advisement">Specifications SHOULD NOT define a string as a 'byte string'.</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
@@ -1720,12 +1738,6 @@ just as characters are the basic unit of organization of encoded text.</p>
 	</details>
 </div>
 
- 	<div class="req" id="char_string_char">
-	<p class="advisement">The 'character string' definition SHOULD be used by most specifications.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C012</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
-	</details>
-	</div>
 </section>
 
 <section id="char_whitespace" class="subtopic">
@@ -2747,10 +2759,6 @@ just as characters are the basic unit of organization of encoded text.</p>
         <li class="w3"><p class="link"><a href="https://www.rfc-editor.org/rfc/rfc3987">Internationalized Resource Identifiers (IRIs)</a> [[RFC3987]]</p></li>
     </ul>
 </aside>
-
-<p>A <dfn id="dfn_resid">resource identifier</dfn> is a compact string of characters for identifying an abstract or physical <a>resource</a>. On the Web, this mostly means various types of Universal Resource Identifiers (or <em>URIs</em>). For wire formats, [[RFC3986]] defines the structure and serialization. <em>Internationalizationed Resource Identifiers</em> (or <em>IRIs</em>) [[RFC3987]] describe how non-ASCII Unicode characters can be used in resource identifiers. The WhatWG [[URL]] specification describes how browsers handle IRIs and their mapping to URIs. See also: <a href="#markup_identifiers"></a>.</p>
-
-<p><dfn id="dfn_percent-encoding" data-lt="percent-encoding|percent encoding|%HH encoding|percent encoded">Percent-encoding</dfn> is the escaping mechanism defined by URI [[RFC3986]] for the encoding of arbitrary byte values not otherwise permitted into a URI. For example, if a user wishes to include the character <span class="codepoint" translate="no"><bdi lang="und">&#x2F;</bdi> [<span class="uname">U+002F SOLIDUS</span>]</span> into a URI, the byte <code>0x2F</code> is encoded as the character sequence <code>%2F</code>. If the user wishes to include the character <span class="codepoint" translate="no"><bdi lang="en">&#x00E9;</bdi> [<span class="uname">U+00E9 LATIN SMALL LETTER E WITH ACUTE</span>]</span> into a URI, the UTF-8 byte sequence for this character (<code>0xC3 0xA9</code>) could be encoded as the sequence <code>%C3%A9</code>.</p>
 
     <p>The situation with regards to specifying support of non-ASCII characters in <a>resource identifiers</a> is complicated because there are at least three specifications (URI [[RFC3986]], IRI [[RFC3987]], and [[URL]]) that define resource identifiers and their serialization. The WhatWG [[URL]] specification is an attempt to address this complexity by documenting the actual practice of browsers and other user agents. The stated goal of the URL specification is to obsolete both RFCs.</p>
     

--- a/index.html
+++ b/index.html
@@ -4196,7 +4196,562 @@ We could stand to cull the Japanese list. The notes need work.
     <td lang="ar" dir="rtl">زفره</td>
     <td>f</td>
     <td>West Asia; Arabic</td>
-    <td>ar
+    <td>ar</td>
+</tr>
+<!-- start CLDR data -->
+ <tr>
+  <td>Anh</td>
+  <td></td>
+  <td>f</td>
+  <td></td>
+  <td>vi</td>
+ </tr>
+ <tr>
+  <td>Bjørn</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>da</td>
+ </tr>
+ <tr>
+  <td>Blerim</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>sq</td>
+ </tr>
+ <tr>
+  <td>Calum</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>gd</td>
+ </tr>
+ <tr>
+  <td>Diego</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>es-419</td>
+ </tr>
+ <tr>
+  <td>F&#259;t-Frumos</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>ro</td>
+ </tr>
+ <tr>
+  <td>Frantziscu</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>sc</td>
+ </tr>
+ <tr>
+  <td>Gurban</td>
+  <td></td>
+  <td></td>
+  <td>Central Asia</td>
+  <td>tk</td>
+ </tr>
+ <tr>
+  <td>Harald</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>no</td>
+ </tr>
+ <tr>
+  <td>Hassan</td>
+  <td></td>
+  <td>m</td>
+  <td></td>
+  <td>sw</td>
+ </tr>
+ <tr>
+  <td>Ivan</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>sr-Latn</td>
+ </tr>
+ <tr>
+  <td>J&#257;nis</td>
+  <td></td>
+  <td>f, m</td>
+  <td>Europe</td>
+  <td>lv</td>
+ </tr>
+ <tr>
+  <td>Jaume</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>ca</td>
+ </tr>
+ <tr>
+  <td>Ji&#345;í</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>cs</td>
+ </tr>
+ <tr>
+  <td>Jozef</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>sk</td>
+ </tr>
+ <tr>
+  <td>Jurij</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>hsb</td>
+ </tr>
+ <tr>
+  <td>Juro</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>dsb</td>
+ </tr>
+ <tr>
+  <td>Lena</td>
+  <td></td>
+  <td>f</td>
+  <td>Europe</td>
+  <td>de</td>
+ </tr>
+ <tr>
+  <td>Liam</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>nl-BE</td>
+ </tr>
+ <tr>
+  <td>Lola</td>
+  <td></td>
+  <td>f</td>
+  <td>Europe</td>
+  <td>es</td>
+ </tr>
+ <tr>
+  <td>Louhi</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>fi</td>
+ </tr>
+ <tr>
+  <td>Marcel</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>fr</td>
+ </tr>
+ <tr>
+  <td>Mari</td>
+  <td></td>
+  <td>f</td>
+  <td>Europe</td>
+  <td>et</td>
+ </tr>
+ <tr>
+  <td>Maria</td>
+  <td></td>
+  <td>f</td>
+  <td>Europe</td>
+  <td>pt</td>
+ </tr>
+ <tr>
+  <td>Mario</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>it, qu</td>
+ </tr>
+ <tr>
+  <td>Piet</td>
+  <td></td>
+  <td>m</td>
+  <td></td>
+  <td>af</td>
+ </tr>
+ <tr>
+  <td>Rokas</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>lt</td>
+ </tr>
+ <tr>
+  <td>Sendoa</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>eu</td>
+ </tr>
+ <tr>
+  <td>sibadì</td>
+  <td></td>
+  <td></td>
+  <td>Africa</td>
+  <td>yo, yo-BJ</td>
+ </tr>
+ <tr>
+  <td>Sigurður</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>is</td>
+ </tr>
+ <tr>
+  <td>sinbad</td>
+  <td></td>
+  <td>m</td>
+  <td></td>
+  <td>ig</td>
+ </tr>
+ <tr>
+  <td>Sinbad</td>
+  <td></td>
+  <td>m</td>
+  <td></td>
+  <td>az, bs, cy, en, fil, ga, ha, ha-NE, id, jv, nl, pcm, pl, so, tr, zu</td>
+ </tr>
+ <tr>
+  <td>Sinbod</td>
+  <td></td>
+  <td>m</td>
+  <td>Central Asia</td>
+  <td>uz</td>
+ </tr>
+ <tr>
+  <td>Slavko</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>hr</td>
+ </tr>
+ <tr>
+  <td>Stefan</td>
+  <td></td>
+  <td>m</td>
+  <td>Europe</td>
+  <td>sv</td>
+ </tr>
+ <tr>
+  <td>Sulaiman</td>
+  <td></td>
+  <td>m</td>
+  <td>Central Asia</td>
+  <td>ms</td>
+ </tr>
+ <tr>
+  <td>Svarun</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>sl</td>
+ </tr>
+ <tr>
+  <td>T&#275;vita</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>to</td>
+ </tr>
+ <tr>
+  <td>Uxía</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>gl</td>
+ </tr>
+ <tr>
+  <td>Vuk</td>
+  <td></td>
+  <td></td>
+  <td>Europe</td>
+  <td>hu</td>
+ </tr>
+ <tr>
+  <td>Yann</td>
+  <td></td>
+  <td>m</td>
+  <td></td>
+  <td>br</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=D&#275;m&#7703;tr&#275;s>&#916;&#951;&#956;&#942;&#964;&#961;&#951;&#962;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>el</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title="Vasíl&#697;">&#1042;&#1072;&#1089;&#1110;&#1083;&#1100;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>be</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Ivan>&#1048;&#1074;&#1072;&#1085;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>bg, sr</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Krste>&#1050;&#1088;&#1089;&#1090;&#1077;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>mk</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=N&#1201;rlan>&#1053;&#1201;&#1088;&#1083;&#1072;&#1085;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>kk</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Sergej>&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>ru</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Sinbad>&#1057;&#1080;&#1085;&#1073;&#1072;&#1076;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>mn</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Syjmyk>&#1057;&#1099;&#1081;&#1084;&#1099;&#1082;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>ky</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Ûríj>&#1070;&#1088;&#1110;&#1081;</span></td>
+  <td></td>
+  <td>Europe</td>
+  <td>uk</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=Art&#699;ur>&#1329;&#1408;&#1385;&#1400;&#1410;&#1408;</span></td>
+  <td></td>
+  <td></td>
+  <td>hy</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td dir=rtl><span title=ywn&#355;n>&#1497;&#1493;&#1504;&#1514;&#1503;</span></td>
+  <td></td>
+  <td></td>
+  <td>he</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td dir=rtl><span title=&#7841;&#7717;md>&#1575;&#1581;&#1605;&#1583;</span></td>
+  <td></td>
+  <td></td>
+  <td>ur</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td dir=rtl><span title=snb&#7841;d>&#1587;&#1606;&#1576;&#1575;&#1583;</span></td>
+  <td></td>
+  <td></td>
+  <td>ps, sd</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td dir=rtl><span title=sndb&#7841;d>&#1587;&#1606;&#1583;&#1576;&#1575;&#1583;</span></td>
+  <td></td>
+  <td></td>
+  <td>fa</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td dir=rtl><span title=mnyr>&#1605;&#1606;&#1610;&#1585;</span></td>
+  <td></td>
+  <td></td>
+  <td>ar</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sin&#477;b&#257;d>&#4658;&#4757;&#4707;&#4853;</span></td>
+  <td></td>
+  <td>Africa</td>
+  <td>am</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=r&#257;ja>&#2352;&#2366;&#2332;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>kok</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=lalita>&#2354;&#2354;&#2367;&#2340;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>hi</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sindab&#257;da>&#2360;&#2367;&#2306;&#2342;&#2348;&#2366;&#2342;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>mr</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sundara>&#2360;&#2369;&#2344;&#2381;&#2342;&#2352;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>ne</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=cindab&#257;da>&#2458;&#2495;&#2472;&#2509;&#2470;&#2476;&#2494;&#2470;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>as</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sinab&#257;da>&#2488;&#2495;&#2472;&#2476;&#2494;&#2470;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>bn</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sinav&#257;da>&#2616;&#2623;&#2600;&#2613;&#2622;&#2598;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>pa</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sinab&#257;da>&#2744;&#2751;&#2728;&#2732;&#2750;&#2726;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>gu</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=sinab&#257;d>&#2872;&#2879;&#2856;&#2860;&#2878;&#2854;&#2893;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>or</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=r&#257;j&#275;ntira&#7753;>&#2992;&#3006;&#2972;&#3015;&#2984;&#3021;&#2980;&#3007;&#2992;&#2985;&#3021;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>ta</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=r&#257;ja&#347;&#275;khar>&#3120;&#3134;&#3100;&#3126;&#3143;&#3094;&#3120;&#3149;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>te</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title="sin&#8204;b&#257;d">&#3256;&#3263;&#3240;&#3277;&#8204;&#3244;&#3262;&#3238;&#3277;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>kn</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=si&#3451;b&#257;&#7693;>&#3384;&#3391;&#3451;&#3372;&#3390;&#3361;&#3405;</span></td>
+  <td></td>
+  <td>South Asia</td>
+  <td>ml</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td>&#3523;&#3538;&#3505;&#3530;&#3510;&#3537;&#3497;&#3530;</td>
+  <td></td>
+  <td>South Asia</td>
+  <td>si</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td><span title=&#7789;hn&#257;>&#3608;&#3609;&#3634;</span></td>
+  <td></td>
+  <td>South-east Asia</td>
+  <td>th</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td>&#3722;&#3764;&#3737;&#3777;&#3738;&#3732;</td>
+  <td></td>
+  <td>South Asia</td>
+  <td>lo</td>
+ </tr>
+ <tr>
+  <td></td>
+  <td>&#6047;&#6075;&#6017;&#6070;</td>
+  <td></td>
+  <td>South Asia</td>
+  <td>km</td>
+ </tr>
+ <tr>
+  <td>Yumi</td>
+  <td>&#50976;&#48120;</td>
+  <td></td>
+  <td>East Asia</td>
+  <td>ko</td>
+ </tr>
+ <tr>
+  <td>dà wén</td>
+  <td>&#22823;&#25991;</td>
+  <td></td>
+  <td>East Asia</td>
+  <td>yue-Hans</td>
+ </tr>
+ <tr>
+  <td>y&#468; hàn</td>
+  <td>&#23431;&#28698;</td>
+  <td></td>
+  <td>East Asia</td>
+  <td>zh</td>
+ </tr>
+ <tr>
+  <td>shèn tài láng</td>
+  <td>&#24910;&#22826;&#37070;</td>
+  <td></td>
+  <td>East Asia</td>
+  <td>ja</td>
+ </tr>
+ <tr>
+  <td>wén jié</td>
+  <td>&#25991;&#20625;</td>
+  <td></td>
+  <td>East Asia</td>
+  <td>yue, zh-Hant</td>
+ </tr>
 </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -1715,6 +1715,10 @@ just as characters are the basic unit of organization of encoded text.</p>
 
 <p>Specifications need to be clear about the encoding and processing of textual data. The recommendations in this section are mutually consistent with those in [[DESIGN-PRINCIPLES]]. In general, specifications should only support well-formed Unicode code point strings and should avoid the use of (or access to) the underlying code units or the use of different character encodings.</p>
 
+<aside class="note">
+	<p>Specifications should avoid adding or defining support for <a>legacy character encodings</a> unless there is a specific reason to do so. See also <a href="#char_choosing"></a>.</p>
+</aside>
+
 <div class="req" id="char_string_char">
 	<p class="advisement">Specifications SHOULD define strings as a sequence of <a>Unicode code points</a>.</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
@@ -1726,15 +1730,23 @@ just as characters are the basic unit of organization of encoded text.</p>
 	<p class="advisement">When designing a web platform feature which operates on strings, use <a href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a> unless you have a specific reason not to.</p>
 </div>
 
-<aside class="note">
-	<p>The type <code>DOMString</code> is actually a UTF-16 <a>code unit</a> string. This type allows unpaired <a>surrogate</a> code units to appear in a string, which can result in errors or replacement with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi> [<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>)</p>
-</aside>
+<p>The type <code>DOMString</code> is actually a UTF-16 <a>code unit</a> string. This type allows unpaired <a>surrogate</a> code units to appear in a string, which can result in errors or replacement with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi> [<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>). This type is appropriate when specifications do not need to do internal processing of the string value. The alternative type is <code translate="no"><a href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></code>, which is a sequence of Unicode code points.</p>
+
+<p>The reason <code translate="no">DOMString</code> is preferred to <code translate="no">USVString</code> is that both [[DOM]] and the string types in JavaScript (and its derivatives, such as JSON) are defined in terms of UTF-16 code unit strings. Specifying <code translate="no">USVString</code> can result in inadvertently requiring an implementation to check for unpaired surrogates in cases where there is no benefit to doing so.</p>
+
+<div class="req" id="char_string_usvstring">
+	<p class="advisement">When designing a web platform feature or API that operates on the internal values of strings, including indexing, iterating, transformation, or searching, the use of <a href="">USVString</a> is RECOMMENDED.</p>
+	<details class="links"><summary>explantations &amp; examples</summary>
+	<p><a href="https://infra.spec.whatwg.org/#scalar-value-string">Scalar value string</a> definition in [[INFRA]]</p>
+	</details>
+</div>
 
 
 <div class="req" id="char_string_byte">
 	<p class="advisement">Specifications SHOULD NOT define a string as a 'byte string'.</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
 	<p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C011</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
+	<p><a href="https://www.w3.org/TR/string-meta/#protocol-strings">Strings that are part of a legacy protocol or format</a>, in <cite>Strings on the Web: Language and Direction Metadata</cite> [[STRING-META]]</p>
 	</details>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -1715,19 +1715,16 @@ just as characters are the basic unit of organization of encoded text.</p>
 
 <p>Specifications need to be clear about the encoding and processing of textual data. The recommendations in this section are mutually consistent with those in [[DESIGN-PRINCIPLES]]. In general, specifications should only support well-formed Unicode code point strings and should avoid the use of (or access to) the underlying code units or the use of different character encodings.</p>
 
-<aside class="note">
+<aside class="note" id="char_string_char">
 	<p>Specifications should avoid adding or defining support for <a>legacy character encodings</a> unless there is a specific reason to do so. See also <a href="#char_choosing"></a>.</p>
 </aside>
 
-<div class="req" id="char_string_char">
-	<p class="advisement">Specifications SHOULD define strings as a sequence of <a>Unicode code points</a>.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	   <p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C012</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
-	</details>
-</div>
-
 <div class="req" id="char_string_domstring">
 	<p class="advisement">When designing a web platform feature which operates on strings, use <a href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a> unless you have a specific reason not to.</p>
+	<details class="links"><summary>explanations &amp; examples</summary>
+	   <p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C012</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
+	   <p><a href="https://www.w3.org/TR/design-principles/#idl-string-types">IDL String Types</a> in <cite>Web Platform Design Principles</cite> [[DESIGN-PRINCIPLES]]</p>
+	</details>
 </div>
 
 <p>The type <code>DOMString</code> is actually a UTF-16 <a>code unit</a> string. This type allows unpaired <a>surrogate</a> code units to appear in a string, which can result in errors or replacement with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi> [<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>). This type is appropriate when specifications do not need to do internal processing of the string value. The alternative type is <code translate="no"><a href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></code>, which is a sequence of Unicode code points.</p>
@@ -1737,18 +1734,26 @@ just as characters are the basic unit of organization of encoded text.</p>
 <div class="req" id="char_string_usvstring">
 	<p class="advisement">When designing a web platform feature or API that operates on the internal values of strings, including indexing, iterating, transformation, or searching, the use of <a href="">USVString</a> is RECOMMENDED.</p>
 	<details class="links"><summary>explantations &amp; examples</summary>
-	<p><a href="https://infra.spec.whatwg.org/#scalar-value-string">Scalar value string</a> definition in [[INFRA]]</p>
+	   <p><a href="https://infra.spec.whatwg.org/#scalar-value-string">Scalar value string</a> definition in [[INFRA]]</p>
+	   <p><a href="https://www.w3.org/TR/design-principles/#idl-string-types">IDL String Types</a> in <cite>Web Platform Design Principles</cite> [[DESIGN-PRINCIPLES]]</p>
 	</details>
 </div>
+
+<p>The type <code translate="no">USVString</code> defines strings as a sequence of Unicode <a>code points</a>. For strings whose most common algorithms operate on or process individual <a>code points</a>, or for operations which can’t handle surrogates in input, <code translate="no">USVString</code> should be used. For example, if your specification is defining a process that parses a string or transforms specific characters, it is both easier to specify and more reliable to refer to code points (<em>"scalar values"</em>) than to deal with the UTF-16 <a>code units</a>.</p>
+
+<p>In a <code translate="no">USVString</code>, isolated <a>surrogate</a> code points are invalid and implementations are required to replace any found in a string with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi>[<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>).</p>
 
 
 <div class="req" id="char_string_byte">
-	<p class="advisement">Specifications SHOULD NOT define a string as a 'byte string'.</p>
+	<p class="advisement">Specifications SHOULD NOT define a string as a <code translate="no">ByteString</code> or as a sequence of bytes ('byte string'). For binary data or sequences of bytes, use <code translate="no">Uint8Array</code> instead.</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C011</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
-	<p><a href="https://www.w3.org/TR/string-meta/#protocol-strings">Strings that are part of a legacy protocol or format</a>, in <cite>Strings on the Web: Language and Direction Metadata</cite> [[STRING-META]]</p>
+	   <p><a href="https://www.w3.org/TR/charmod/#sec-Strings">String concepts, C011</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite>.</p>
+	   <p><a href="https://www.w3.org/TR/string-meta/#protocol-strings">Strings that are part of a legacy protocol or format</a>, in <cite>Strings on the Web: Language and Direction Metadata</cite> [[STRING-META]]</p>
+	   <p><a href="https://www.w3.org/TR/design-principles/#idl-string-types">IDL String Types</a> in <cite>Web Platform Design Principles</cite> [[DESIGN-PRINCIPLES]]</p>
 	</details>
 </div>
+
+<p>The type <code translate="no">ByteString</code> defines strings as sequences of bytes (octets). Interpretation of byte strings thus requires the specification of a <a>character encoding form</a>. UTF-8 is the preferred encoding for wire and document formats [[ENCODING]], but there is generally no reason to specify strings in terms of the underlying byte values. See <a href="#char_choosing"></a> for additional best practices.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
   </script>
   </head>
   
-  <body onload="sortTable('exampleNamesTable', 0, false); sortTable('cldrExampleNamesTable', 0, false);">
+  <body onload="sortTable('exampleNamesTable', 0, false);">
   <div id="abstract">
       <p>This document provides a checklist of internationalization-related considerations when developing a specification. Most checklist items point to detailed supporting information in other documents. Where such information does not yet exist, it can be given a temporary home in this document.  <strong>The  information in this document will change regularly as new content is added and existing content is modified in the light of experience and discussion.</strong></p>
   </div>
@@ -4203,7 +4203,13 @@ PCENChar ::=
 </tbody>
 </table>
 
+<aside class="note">
+    <p>Another potential source for example names is Unicode's <cite>Common Locale Data Repository</cite> [[CLDR]] project, which maintains data about the presentation of personal names in different [= locales =] and cultures. That set of names can be accessed on CLDR's <a href="https://unicode-org.github.io/cldr-staging/charts/latest/by_type/miscellaneous.person_name_formats.html#SampleName_Fields_for_Item:_givenOnly">charts page</a>. Note that those names were collected with a focus on providing examples of the <em>formatting</em> of personal names, rather than as examples of typical names found in these cultures. For example, many of the names are variations on the name "Sinbad", even though "Sinbad" is not a commonly used name in many of these cultures. Other names are taken from sources, such as folk tales, that would be familiar in a given culture but not representative of actual persons.</p>
+</aside>
+
 <!-- start CLDR data -->
+<!--  commented out as a WG decision in teleconference of 2022-12-15
+      also removed this from the body onload: sortTable('cldrExampleNamesTable', 0, false);
 <h5>CLDR sample names</h5>
 
 <p>The following list of names is taken from Unicode's <cite>Common Locale Data Repository</cite> [[CLDR]] project, which maintains data about the presentation of personal names in different [= locales =] and cultures. In addition to the table below, this set of names can be accessed on CLDR's <a href="https://unicode-org.github.io/cldr-staging/charts/latest/by_type/miscellaneous.person_name_formats.html#SampleName_Fields_for_Item:_givenOnly">charts page</a>. Note that these names were collected with a focus on providing examples of the <em>formatting</em> of personal names, rather than as examples of typical names found in these cultures. For example, many of the names are variations on the name "Sinbad", even though "Sinbad" is not a commonly used name in many of these cultures. Other names are taken from sources, such as folk tales, that would be familiar in a given culture but not representative of actual persons.</p>
@@ -4745,7 +4751,7 @@ PCENChar ::=
   <td>East Asia; Korean</td>
   <td>ko</td>
  </tr>
- <!-- Dai Bun
+ <-- Dai Bun
  <tr>
   <td>dà wén</td>
   <td>&#22823;&#25991;</td>
@@ -4753,8 +4759,7 @@ PCENChar ::=
   <td>East Asia</td>
   <td>yue-Hans</td>
  </tr>
- -->
- <!-- Unihan?
+ <-- Unihan?
  <tr>
   <td>y&#468; hàn</td>
   <td>&#23431;&#28698;</td>
@@ -4762,7 +4767,7 @@ PCENChar ::=
   <td>East Asia</td>
   <td>zh</td>
  </tr>
- -->
+
  <tr>
   <td>Shintaro</td>
   <td>&#24910;&#22826;&#37070;</td>
@@ -4782,26 +4787,7 @@ PCENChar ::=
 
 <hr>
 
-
-
-
-<p style="display:none">Old examples being removed: 
-Chanda, Charun,    <!-- Hindi -->
-Dara, Damilola,    <!-- Yoruba -->
-Genet, Gebre,      <!-- Ethiopian -->
-Hatsue, Hiroki,    <!-- Japanese -->
-Júlía, Jökull,     <!-- Icelandic -->
-Khaliun, Khuyag,   <!-- Mongolian -->
-Ngatemi, Nugroho,  <!-- Javanese (Indonesia) -->
-Onya, Omari,       <!-- Tanzania (Swahili) -->
-Potira, Piatã,     <!-- Tupi, Guarani -->
-Qiàn (倩), Qiáng (强),         <!-- Chinese -->
-, ,  <!-- Thai -->
-Tuqiik, Tinmiak,   <!-- Yupik, Inupiat -->
-Uri (אוּרִי), ,  <!-- Hebrew -->
-Xiaoxia (晓霞), Xīn (鑫),      <!-- Chinese -->
-Zafirah, Zain      <!-- Arabic -->
-</p>
+-->
 
 </section>
 </section>

--- a/index.html
+++ b/index.html
@@ -4378,70 +4378,70 @@ We could stand to cull the Japanese list. The notes need work.
   <td>Piet</td>
   <td></td>
   <td>m</td>
-  <td></td>
+  <td>Africa, South Africa (Afrikaans)</td>
   <td>af</td>
  </tr>
  <tr>
   <td>Rokas</td>
   <td></td>
-  <td></td>
-  <td>Europe</td>
+  <td>m</td>
+  <td>Europe, Latvia</td>
   <td>lt</td>
  </tr>
  <tr>
   <td>Sendoa</td>
   <td></td>
   <td></td>
-  <td>Europe</td>
+  <td>Europe, Spain (Basque)</td>
   <td>eu</td>
  </tr>
  <tr>
   <td>sibadì</td>
   <td></td>
-  <td></td>
-  <td>Africa</td>
+  <td>m</td>
+  <td>Africa, Benin (Yoruba)</td>
   <td>yo, yo-BJ</td>
  </tr>
  <tr>
   <td>Sigurður</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe, Iceland</td>
   <td>is</td>
  </tr>
  <tr>
   <td>sinbad</td>
   <td></td>
   <td>m</td>
-  <td></td>
+  <td>Africa, Nigeria</td>
   <td>ig</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td></td>
   <td>m</td>
-  <td></td>
+  <td>Europe, Central Asia</td>
   <td>az, bs, cy, en, fil, ga, ha, ha-NE, id, jv, nl, pcm, pl, so, tr, zu</td>
  </tr>
  <tr>
   <td>Sinbod</td>
   <td></td>
   <td>m</td>
-  <td>Central Asia</td>
+  <td>Central Asia, Uzbekistan</td>
   <td>uz</td>
  </tr>
  <tr>
   <td>Slavko</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe, Hungary</td>
   <td>hr</td>
  </tr>
  <tr>
   <td>Stefan</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe, Sweden</td>
   <td>sv</td>
  </tr>
  <tr>
@@ -4455,209 +4455,209 @@ We could stand to cull the Japanese list. The notes need work.
   <td>Svarun</td>
   <td></td>
   <td></td>
-  <td></td>
+  <td>Europe, Slovenia</td>
   <td>sl</td>
  </tr>
  <tr>
   <td>T&#275;vita</td>
   <td></td>
   <td></td>
-  <td></td>
+  <td>Oceania, Tonga</td>
   <td>to</td>
  </tr>
  <tr>
   <td>Uxía</td>
   <td></td>
-  <td></td>
-  <td></td>
+  <td>f</td>
+  <td>Europe, Spain (Galician)</td>
   <td>gl</td>
  </tr>
  <tr>
   <td>Vuk</td>
   <td></td>
-  <td></td>
-  <td>Europe</td>
+  <td>m</td>
+  <td>Europe, Hungary</td>
   <td>hu</td>
  </tr>
  <tr>
   <td>Yann</td>
   <td></td>
   <td>m</td>
-  <td></td>
+  <td>Europe, France (Breton)</td>
   <td>br</td>
  </tr>
  <tr>
   <td></td>
   <td><span title=D&#275;m&#7703;tr&#275;s>&#916;&#951;&#956;&#942;&#964;&#961;&#951;&#962;</span></td>
   <td></td>
-  <td>Europe</td>
+  <td>Europe, Greece</td>
   <td>el</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title="Vasíl&#697;">&#1042;&#1072;&#1089;&#1110;&#1083;&#1100;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Vasíl&#697;</td>
+  <td>&#1042;&#1072;&#1089;&#1110;&#1083;&#1100;</td>
+  <td>m</td>
+  <td>Europe, Belarus</td>
   <td>be</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Ivan>&#1048;&#1074;&#1072;&#1085;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Ivan</td>
+  <td>&#1048;&#1074;&#1072;&#1085;</td>
+  <td>m</td>
+  <td>Europe, Bulgaria, Serbia</td>
   <td>bg, sr</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Krste>&#1050;&#1088;&#1089;&#1090;&#1077;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Krste</td>
+  <td>&#1050;&#1088;&#1089;&#1090;&#1077;</td>
+  <td>m</td>
+  <td>Europe, North Macedonia</td>
   <td>mk</td>
  </tr>
  <tr>
+  <td>N&#1201;rlan</td>
+  <td>&#1053;&#1201;&#1088;&#1083;&#1072;&#1085;</td>
   <td></td>
-  <td><span title=N&#1201;rlan>&#1053;&#1201;&#1088;&#1083;&#1072;&#1085;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Central Asia, Kazakhstan</td>
   <td>kk</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Sergej>&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Sergey</td>
+  <td>&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;</td>
+  <td>m</td>
+  <td>Europe, Russia</td>
   <td>ru</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Sinbad>&#1057;&#1080;&#1085;&#1073;&#1072;&#1076;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Sinbad</td>
+  <td>&#1057;&#1080;&#1085;&#1073;&#1072;&#1076;</td>
+  <td>m</td>
+  <td>East Asia, Mongolia</td>
   <td>mn</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Syjmyk>&#1057;&#1099;&#1081;&#1084;&#1099;&#1082;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Syjmyk, Symyk</td>
+  <td>&#1057;&#1099;&#1081;&#1084;&#1099;&#1082;</td>
+  <td>m</td>
+  <td>Central Asia, Kyrgyzstan</td>
   <td>ky</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Ûríj>&#1070;&#1088;&#1110;&#1081;</span></td>
-  <td></td>
-  <td>Europe</td>
+  <td>Yuriy, Ûríj</td>
+  <td>&#1070;&#1088;&#1110;&#1081;</td>
+  <td>m</td>
+  <td>Europe, Ukraine</td>
   <td>uk</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=Art&#699;ur>&#1329;&#1408;&#1385;&#1400;&#1410;&#1408;</span></td>
-  <td></td>
-  <td></td>
+  <td>Art&#699;ur</td>
+  <td>&#1329;&#1408;&#1385;&#1400;&#1410;&#1408;</td>
+  <td>m</td>
+  <td>Europe, Armenia</td>
   <td>hy</td>
  </tr>
  <tr>
+  <td>Yonatan (Jonathan)</td>
+  <td dir=rtl>&#1497;&#1493;&#1504;&#1514;&#1503;</td>
   <td></td>
-  <td dir=rtl><span title=ywn&#355;n>&#1497;&#1493;&#1504;&#1514;&#1503;</span></td>
-  <td></td>
-  <td></td>
+  <td>West Asia, Hebrew</td>
   <td>he</td>
  </tr>
  <tr>
-  <td></td>
-  <td dir=rtl><span title=&#7841;&#7717;md>&#1575;&#1581;&#1605;&#1583;</span></td>
+  <td>&#7841;&#7717;md</td>
+  <td dir=rtl>&#1575;&#1581;&#1605;&#1583;</td>
   <td></td>
   <td></td>
   <td>ur</td>
  </tr>
  <tr>
-  <td></td>
-  <td dir=rtl><span title=snb&#7841;d>&#1587;&#1606;&#1576;&#1575;&#1583;</span></td>
+  <td>Sindbad</td>
+  <td dir=rtl>&#1587;&#1606;&#1576;&#1575;&#1583;</td>
   <td></td>
   <td></td>
   <td>ps, sd</td>
  </tr>
  <tr>
-  <td></td>
-  <td dir=rtl><span title=sndb&#7841;d>&#1587;&#1606;&#1583;&#1576;&#1575;&#1583;</span></td>
+  <td>Sinbad</td>
+  <td dir=rtl>&#1587;&#1606;&#1583;&#1576;&#1575;&#1583;</td>
   <td></td>
   <td></td>
   <td>fa</td>
  </tr>
  <tr>
-  <td></td>
-  <td dir=rtl><span title=mnyr>&#1605;&#1606;&#1610;&#1585;</span></td>
-  <td></td>
-  <td></td>
+  <td>Munir</td>
+  <td dir=rtl>&#1605;&#1606;&#1610;&#1585;</td>
+  <td>m</td>
+  <td>West Asia, Arabic</td>
   <td>ar</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sin&#477;b&#257;d>&#4658;&#4757;&#4707;&#4853;</span></td>
-  <td></td>
-  <td>Africa</td>
+  <td>Sinbad</td>
+  <td>&#4658;&#4757;&#4707;&#4853;</td>
+  <td>m</td>
+  <td>Africa, Ethiopia</td>
   <td>am</td>
  </tr>
  <tr>
-  <td></td>
+  <td>Raj</td>
   <td><span title=r&#257;ja>&#2352;&#2366;&#2332;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>m</td>
+  <td>South Asia, Konkani</td>
   <td>kok</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=lalita>&#2354;&#2354;&#2367;&#2340;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Lalita</td>
+  <td>&#2354;&#2354;&#2367;&#2340;</td>
+  <td>f</td>
+  <td>South Asia, India (Hindi)</td>
   <td>hi</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sindab&#257;da>&#2360;&#2367;&#2306;&#2342;&#2348;&#2366;&#2342;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sindab&#257;da</td>
+  <td>&#2360;&#2367;&#2306;&#2342;&#2348;&#2366;&#2342;</td>
+  <td>m</td>
+  <td>South Asia, India (Marathi)</td>
   <td>mr</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sundara>&#2360;&#2369;&#2344;&#2381;&#2342;&#2352;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sundara</td>
+  <td>&#2360;&#2369;&#2344;&#2381;&#2342;&#2352;</td>
+  <td>f</td>
+  <td>South Asia, Nepal</td>
   <td>ne</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=cindab&#257;da>&#2458;&#2495;&#2472;&#2509;&#2470;&#2476;&#2494;&#2470;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#2458;&#2495;&#2472;&#2509;&#2470;&#2476;&#2494;&#2470;</td>
+  <td>m</td>
+  <td>South Asia, India (Assamese)</td>
   <td>as</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sinab&#257;da>&#2488;&#2495;&#2472;&#2476;&#2494;&#2470;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#2488;&#2495;&#2472;&#2476;&#2494;&#2470;</td>
+  <td>m</td>
+  <td>South Asia, India (Bengali)</td>
   <td>bn</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sinav&#257;da>&#2616;&#2623;&#2600;&#2613;&#2622;&#2598;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#2616;&#2623;&#2600;&#2613;&#2622;&#2598;</td>
+  <td>m</td>
+  <td>South Asia, Punjabi</td>
   <td>pa</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sinab&#257;da>&#2744;&#2751;&#2728;&#2732;&#2750;&#2726;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#2744;&#2751;&#2728;&#2732;&#2750;&#2726;</td>
+  <td>m</td>
+  <td>South Asia, India (Gujarati)</td>
   <td>gu</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=sinab&#257;d>&#2872;&#2879;&#2856;&#2860;&#2878;&#2854;&#2893;</span></td>
-  <td></td>
+  <td>Sinbad</td>
+  <td>&#2872;&#2879;&#2856;&#2860;&#2878;&#2854;&#2893;</td>
+  <td>m</td>
   <td>South Asia</td>
   <td>or</td>
  </tr>
@@ -4665,7 +4665,7 @@ We could stand to cull the Japanese list. The notes need work.
   <td></td>
   <td><span title=r&#257;j&#275;ntira&#7753;>&#2992;&#3006;&#2972;&#3015;&#2984;&#3021;&#2980;&#3007;&#2992;&#2985;&#3021;</span></td>
   <td></td>
-  <td>South Asia</td>
+  <td>South Asia, India (Tamil)</td>
   <td>ta</td>
  </tr>
  <tr>

--- a/index.html
+++ b/index.html
@@ -1741,7 +1741,7 @@ just as characters are the basic unit of organization of encoded text.</p>
 
 <p>The type <code translate="no">USVString</code> defines strings as a sequence of Unicode <a>code points</a>. For strings whose most common algorithms operate on or process individual <a>code points</a>, or for operations which can’t handle surrogates in input, <code translate="no">USVString</code> should be used. For example, if your specification is defining a process that parses a string or transforms specific characters, it is both easier to specify and more reliable to refer to code points (<em>"scalar values"</em>) than to deal with the UTF-16 <a>code units</a>.</p>
 
-<p>In a <code translate="no">USVString</code>, isolated <a>surrogate</a> code points are invalid and implementations are required to replace any found in a string with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi>[<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>).</p>
+<p>In a <code translate="no">USVString</code>, isolated <a>surrogate</a> code points are invalid and implementations are required to replace any found in a string with the Unicode replacment character (<span class="codepoint" translate="no"><bdi lang="und">&#xFFFD;</bdi> [<span class="uname">U+FFFD REPLACEMENT CHARACTER</span>]</span>).</p>
 
 
 <div class="req" id="char_string_byte">

--- a/index.html
+++ b/index.html
@@ -63,9 +63,10 @@
   </script>
   
   <script>
-	  function sortTable(colNum, reversed) {
+	  function sortTable(tableName, colNum, reversed) {
           var table, rows, i, x, y, shouldSwitch;
-          table = document.getElementById("exampleNamesTable");
+          table = document.getElementById(tableName);
+          if ( ! table) return;
           var switching = true;
           var collator = new Intl.Collator('en-US');
   
@@ -104,7 +105,7 @@
   </script>
   </head>
   
-  <body onload="sortTable(0, false);">
+  <body onload="sortTable('exampleNamesTable', 0, false); sortTable('cldrExampleNamesTable', 0, false);">
   <div id="abstract">
       <p>This document provides a checklist of internationalization-related considerations when developing a specification. Most checklist items point to detailed supporting information in other documents. Where such information does not yet exist, it can be given a temporary home in this document.  <strong>The  information in this document will change regularly as new content is added and existing content is modified in the light of experience and discussion.</strong></p>
   </div>
@@ -3672,34 +3673,30 @@ PCENChar ::=
 
 <p>No collection of names can be completely agnostic in dealing with cultural and gender-related issues. To assist specification writers in creating more inclusive examples, this document provides a collection of names drawn from across many cultures. These names are organized approximately into regions, usually indicating country or language. Notice that even within these regions there are quite diverse influences and practices for the handling of personal names. The names are also divided by their cultural gender association to assist specification authors in writing examples, although many names are not specific to any particular gender.</p>
 
-<aside class="note">
+<p>Inserting personal names from other cultures into English-language examples is also affected by the very different ways that names are used culturally around the world. For example, some cultures expect the use of a patronym/matronym in addition to the given name; or some cultures prefer more formal names (e.g. "<em>Herr Dürer</em>" vs. the informal "<em>Albrecht</em>").</p>
+
+<p>Chinese people almost never use their given name without also including their family name. When writing examples in Chinese, one might see something like <span lang="zh-Hans">路人甲</span> (it means Person A, using the Han "Heavenly Stem" ordinals, cf. <a href="https://www.w3.org/TR/predefined-counter-styles/#cjk-heavenly-stem">Ready-made Counter Styles</a>) rather than a "exemplar name". When examples are used, they include both the family and given name. Bear in mind that in Chinese the family name comes first, before the given name.</p>
+
+<p>In Japanese, there are complex choices related to levels of formality. A person <em>might</em> be addressed by their given name in very informal situations (<em>Hiroshi</em>), but usually will be addressed with a family name that includes (unless one is being rude) a title or suffix, such as <code>-san</code> or <code>-sama</code> (e.g. <em>Tanaka-san</em>). Other suffixes or titles are also used, such as <em>senpai</em> or <em>sensei</em> (for senior or very esteemed individuals) or <em>shi</em> (when one is unfamiliar with the person). Thus an example in English that could say <em>Suppose Hiroki wants to set up a...</em> would probably be more culturally appropriate if it read <em>Suppose Tanaka-san wants to set up a...</em></p>
+
+<h5>Example names</h5>
+	
+<p>The following table was compiled by the Internationalization Working Group. Contributions and suggestions for additions or corrections are welcome.</p>
+
 	<p>The purpose of this collection of names is to assist specification authors who are generally writing for an English-speaking audience. The collection consists primarily of given names and, where necessary, is transliterated into the Latin script. The names are also rendered informally (<em>"Alice"</em> rather than <em>"Ms. Jones"</em>), even though this is not how names would be used in many of these cultures. When translating specifications, adjustments should be made which are appropriate for the target audience.</p>
 	
 	<p>When names are taken from non-Latin-script languages or cultures, the non-Latin representation is also provided as a reminder that names are in no way limited to the Latin script or for cases where you want to include a non-Latin script example.</p>
-</aside>
-
-<aside class="note" title="Origin of this data">
-	<p>This list consists of two sets of names. The first set was compiled by the Internationalization Working Group. The second set are taken from Unicode's <cite>Common Locale Data Repository</cite> [[CLDR]] project, which maintains data about the presentation of personal names in different [= locales =] and cultures. In addition to the table below, this second set of names can be accessed on CLDR's <a href="https://unicode-org.github.io/cldr-staging/charts/latest/by_type/miscellaneous.person_name_formats.html#SampleName_Fields_for_Item:_givenOnly">charts page</a>. Note that these names are more frequently associated with the male gender, including a large number of variations on the name "Sinbad".</p>
-</aside>
-
-<!-- 
-What's missing? 
-
-Sub-saharan Africa; more Chinese names; more Indic names; central Asian names
-We could stand to cull the Japanese list. The notes need work.
-
--->
 
 <p><em>This table can be sorted by clicking on the &#x25b3; or &#x25bd; arrows in the header row.</em></p>
 
-<table id="exampleNamesTable">
+<table id="exampleNamesTable" class="exampleNamesTable">
 	<thead>
 		<tr>
-			<th>Name <span onclick="sortTable(0, false)">&#x25b3;</span><span onclick="sortTable(0, true)">&#x25bd;</span></th>
-			<th>Native <span onclick="sortTable(1, false)">&#x25b3;</span><span onclick="sortTable(1, true)">&#x25bd;</span></th>
-			<th>Gender <span onclick="sortTable(2, false)">&#x25b3;</span><span onclick="sortTable(2, true)">&#x25bd;</span></th>
-			<th>Region and Notes <span onclick="sortTable(3, false)">&#x25b3;</span><span onclick="sortTable(3, true)">&#x25bd;</span></th>
-			<th>Language <span onclick="sortTable(4, false)">&#x25b3;</span><span onclick="sortTable(4, true)">&#x25bd;</span></th>
+			<th>Name <span onclick="sortTable('exampleNamesTable', 0, false)">&#x25b3;</span><span onclick="sortTable('exampleNamesTable', 0, true)">&#x25bd;</span></th>
+			<th>Native <span onclick="sortTable('exampleNamesTable', 1, false)">&#x25b3;</span><span onclick="sortTable('exampleNamesTable', 1, true)">&#x25bd;</span></th>
+			<th>Gender <span onclick="sortTable('exampleNamesTable', 2, false)">&#x25b3;</span><span onclick="sortTable('exampleNamesTable', 2, true)">&#x25bd;</span></th>
+			<th>Region and Notes <span onclick="sortTable('exampleNamesTable', 3, false)">&#x25b3;</span><span onclick="sortTable('exampleNamesTable', 3, true)">&#x25bd;</span></th>
+			<th>Language <span onclick="sortTable('exampleNamesTable', 4, false)">&#x25b3;</span><span onclick="sortTable('exampleNamesTable', 4, true)">&#x25bd;</span></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -4203,187 +4200,206 @@ We could stand to cull the Japanese list. The notes need work.
     <td>West Asia; Arabic</td>
     <td>ar</td>
 </tr>
+</tbody>
+</table>
+
 <!-- start CLDR data -->
+<h5>CLDR sample names</h5>
+
+<p>The following list of names is taken from Unicode's <cite>Common Locale Data Repository</cite> [[CLDR]] project, which maintains data about the presentation of personal names in different [= locales =] and cultures. In addition to the table below, this set of names can be accessed on CLDR's <a href="https://unicode-org.github.io/cldr-staging/charts/latest/by_type/miscellaneous.person_name_formats.html#SampleName_Fields_for_Item:_givenOnly">charts page</a>. Note that these names were collected with a focus on providing examples of the <em>formatting</em> of personal names, rather than as examples of typical names found in these cultures. For example, many of the names are variations on the name "Sinbad", even though "Sinbad" is not a commonly used name in many of these cultures. Other names are taken from sources, such as folk tales, that would be familiar in a given culture but not representative of actual persons.</p>
+
+<p><em>This table can be sorted by clicking on the &#x25b3; or &#x25bd; arrows in the header row.</em></p>
+<table id="cldrExampleNamesTable" class="exampleNamesTable">
+	<thead>
+		<tr>
+			<th>Name <span onclick="sortTable('cldrExampleNamesTable', 0, false)">&#x25b3;</span><span onclick="sortTable('cldrExampleNamesTable', 0, true)">&#x25bd;</span></th>
+			<th>Native <span onclick="sortTable('cldrExampleNamesTable', 1, false)">&#x25b3;</span><span onclick="sortTable('cldrExampleNamesTable', 1, true)">&#x25bd;</span></th>
+			<th>Gender <span onclick="sortTable('cldrExampleNamesTable', 2, false)">&#x25b3;</span><span onclick="sortTable('cldrExampleNamesTable', 2, true)">&#x25bd;</span></th>
+			<th>Region and Notes <span onclick="sortTable('cldrExampleNamesTable', 3, false)">&#x25b3;</span><span onclick="sortTable('cldrExampleNamesTable', 3, true)">&#x25bd;</span></th>
+			<th>Language <span onclick="sortTable('cldrExampleNamesTable', 4, false)">&#x25b3;</span><span onclick="sortTable('cldrExampleNamesTable', 4, true)">&#x25bd;</span></th>
+		</tr>
+	</thead>
+	<tbody>
  <tr>
   <td>Anh</td>
   <td></td>
   <td>f</td>
-  <td></td>
+  <td>Southeast Asia; Vietnamese</td>
   <td>vi</td>
  </tr>
  <tr>
   <td>Bjørn</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Danish</td>
   <td>da</td>
  </tr>
  <tr>
   <td>Blerim</td>
   <td></td>
   <td></td>
-  <td>Europe</td>
+  <td>Europe; Albanian</td>
   <td>sq</td>
  </tr>
  <tr>
   <td>Calum</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Gaelic</td>
   <td>gd</td>
  </tr>
  <tr>
   <td>Diego</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Latin American Spanish</td>
   <td>es-419</td>
  </tr>
  <tr>
   <td>F&#259;t-Frumos</td>
   <td></td>
-  <td></td>
-  <td>Europe</td>
+  <td>m</td>
+  <td>Europe; Romania</td>
   <td>ro</td>
  </tr>
  <tr>
   <td>Frantziscu</td>
   <td></td>
-  <td></td>
-  <td></td>
+  <td>m</td>
+  <td>Europe; Sardinian</td>
   <td>sc</td>
  </tr>
  <tr>
   <td>Gurban</td>
   <td></td>
-  <td></td>
-  <td>Central Asia</td>
+  <td>m</td>
+  <td>Central Asia; Tajik, Azerbaijani</td>
   <td>tk</td>
  </tr>
  <tr>
   <td>Harald</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Norwegian</td>
   <td>no</td>
  </tr>
  <tr>
   <td>Hassan</td>
   <td></td>
   <td>m</td>
-  <td></td>
+  <td>Africa; Swahili</td>
   <td>sw</td>
  </tr>
  <tr>
   <td>Ivan</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Serbian (Latin)</td>
   <td>sr-Latn</td>
  </tr>
  <tr>
   <td>J&#257;nis</td>
   <td></td>
   <td>f, m</td>
-  <td>Europe</td>
+  <td>Europe; Latvian</td>
   <td>lv</td>
  </tr>
  <tr>
   <td>Jaume</td>
   <td></td>
-  <td></td>
-  <td>Europe</td>
+  <td>m</td>
+  <td>Europe; Catalan</td>
   <td>ca</td>
  </tr>
  <tr>
   <td>Ji&#345;í</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Czech</td>
   <td>cs</td>
  </tr>
  <tr>
   <td>Jozef</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Slovak</td>
   <td>sk</td>
  </tr>
  <tr>
   <td>Jurij</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Upper Sorbian</td>
   <td>hsb</td>
  </tr>
  <tr>
   <td>Juro</td>
   <td></td>
-  <td></td>
-  <td></td>
+  <td>m</td>
+  <td>Europe; Lower Sorbian</td>
   <td>dsb</td>
  </tr>
  <tr>
   <td>Lena</td>
   <td></td>
   <td>f</td>
-  <td>Europe</td>
+  <td>Europe; German</td>
   <td>de</td>
  </tr>
  <tr>
   <td>Liam</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; Dutch (Flemish)</td>
   <td>nl-BE</td>
  </tr>
  <tr>
   <td>Lola</td>
   <td></td>
   <td>f</td>
-  <td>Europe</td>
+  <td>Europe; Spanish</td>
   <td>es</td>
  </tr>
  <tr>
   <td>Louhi</td>
   <td></td>
-  <td></td>
-  <td>Europe</td>
+  <td>f</td>
+  <td>Europe; Finnish</td>
   <td>fi</td>
  </tr>
  <tr>
   <td>Marcel</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Europe; French</td>
   <td>fr</td>
  </tr>
  <tr>
   <td>Mari</td>
   <td></td>
   <td>f</td>
-  <td>Europe</td>
+  <td>Europe; Estonian</td>
   <td>et</td>
  </tr>
  <tr>
   <td>Maria</td>
   <td></td>
   <td>f</td>
-  <td>Europe</td>
+  <td>Europe; Portuguese</td>
   <td>pt</td>
  </tr>
  <tr>
   <td>Mario</td>
   <td></td>
   <td>m</td>
-  <td>Europe</td>
+  <td>Italian, Quechua</td>
   <td>it, qu</td>
  </tr>
  <tr>
   <td>Piet</td>
   <td></td>
   <td>m</td>
-  <td>Africa, South Africa (Afrikaans)</td>
+  <td>Africa; Afrikaans</td>
   <td>af</td>
  </tr>
  <tr>
@@ -4396,29 +4412,29 @@ We could stand to cull the Japanese list. The notes need work.
  <tr>
   <td>Sendoa</td>
   <td></td>
-  <td></td>
-  <td>Europe, Spain (Basque)</td>
+  <td>m</td>
+  <td>Europe; Basque</td>
   <td>eu</td>
  </tr>
  <tr>
   <td>sibadì</td>
   <td></td>
   <td>m</td>
-  <td>Africa, Benin (Yoruba)</td>
+  <td>Africa; Yoruba</td>
   <td>yo, yo-BJ</td>
  </tr>
  <tr>
   <td>Sigurður</td>
   <td></td>
   <td>m</td>
-  <td>Europe, Iceland</td>
+  <td>Europe; Icelandic</td>
   <td>is</td>
  </tr>
  <tr>
   <td>sinbad</td>
   <td></td>
   <td>m</td>
-  <td>Africa, Nigeria</td>
+  <td>Africa; Igbo</td>
   <td>ig</td>
  </tr>
  <tr>
@@ -4432,91 +4448,91 @@ We could stand to cull the Japanese list. The notes need work.
   <td>Sinbod</td>
   <td></td>
   <td>m</td>
-  <td>Central Asia, Uzbekistan</td>
+  <td>Central Asia; Uzbek</td>
   <td>uz</td>
  </tr>
  <tr>
   <td>Slavko</td>
   <td></td>
   <td>m</td>
-  <td>Europe, Hungary</td>
+  <td>Europe; Hungarian</td>
   <td>hr</td>
  </tr>
  <tr>
   <td>Stefan</td>
   <td></td>
   <td>m</td>
-  <td>Europe, Sweden</td>
+  <td>Europe; Swedish</td>
   <td>sv</td>
  </tr>
  <tr>
   <td>Sulaiman</td>
   <td></td>
   <td>m</td>
-  <td>Central Asia</td>
+  <td>Southeast Asia; Malay</td>
   <td>ms</td>
  </tr>
  <tr>
   <td>Svarun</td>
   <td></td>
   <td></td>
-  <td>Europe, Slovenia</td>
+  <td>Europe; Slovenian</td>
   <td>sl</td>
  </tr>
  <tr>
   <td>T&#275;vita</td>
   <td></td>
   <td></td>
-  <td>Oceania, Tonga</td>
+  <td>Oceania; Tongan</td>
   <td>to</td>
  </tr>
  <tr>
   <td>Uxía</td>
   <td></td>
   <td>f</td>
-  <td>Europe, Spain (Galician)</td>
+  <td>Europe; Galician</td>
   <td>gl</td>
  </tr>
  <tr>
   <td>Vuk</td>
   <td></td>
   <td>m</td>
-  <td>Europe, Hungary</td>
+  <td>Europe; Hungarian</td>
   <td>hu</td>
  </tr>
  <tr>
   <td>Yann</td>
   <td></td>
   <td>m</td>
-  <td>Europe, France (Breton)</td>
+  <td>Europe; Breton</td>
   <td>br</td>
  </tr>
  <tr>
+  <td>Dimitris</td>
+  <td>&#916;&#951;&#956;&#942;&#964;&#961;&#951;&#962;</td>
   <td></td>
-  <td><span title=D&#275;m&#7703;tr&#275;s>&#916;&#951;&#956;&#942;&#964;&#961;&#951;&#962;</span></td>
-  <td></td>
-  <td>Europe, Greece</td>
+  <td>Europe; Greek</td>
   <td>el</td>
  </tr>
  <tr>
   <td>Vasíl&#697;</td>
   <td>&#1042;&#1072;&#1089;&#1110;&#1083;&#1100;</td>
   <td>m</td>
-  <td>Europe, Belarus</td>
+  <td>Europe; Belarussian</td>
   <td>be</td>
  </tr>
  <tr>
   <td>Ivan</td>
   <td>&#1048;&#1074;&#1072;&#1085;</td>
   <td>m</td>
-  <td>Europe, Bulgaria, Serbia</td>
+  <td>Europe, Bulgaria; Serbian</td>
   <td>bg, sr</td>
  </tr>
  <tr>
   <td>Krste</td>
   <td>&#1050;&#1088;&#1089;&#1090;&#1077;</td>
   <td>m</td>
-  <td>Europe, North Macedonia</td>
+  <td>Europe; Macedonian</td>
   <td>mk</td>
  </tr>
  <tr>
@@ -4530,119 +4546,119 @@ We could stand to cull the Japanese list. The notes need work.
   <td>Sergey</td>
   <td>&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;</td>
   <td>m</td>
-  <td>Europe, Russia</td>
+  <td>Europe; Russian</td>
   <td>ru</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td>&#1057;&#1080;&#1085;&#1073;&#1072;&#1076;</td>
   <td>m</td>
-  <td>East Asia, Mongolia</td>
+  <td>East Asia; Mongolian</td>
   <td>mn</td>
  </tr>
  <tr>
   <td>Syjmyk, Symyk</td>
   <td>&#1057;&#1099;&#1081;&#1084;&#1099;&#1082;</td>
   <td>m</td>
-  <td>Central Asia, Kyrgyzstan</td>
+  <td>Central Asia; Kyrgyz</td>
   <td>ky</td>
  </tr>
  <tr>
   <td>Yuriy, Ûríj</td>
   <td>&#1070;&#1088;&#1110;&#1081;</td>
   <td>m</td>
-  <td>Europe, Ukraine</td>
+  <td>Europe; Ukrainian</td>
   <td>uk</td>
  </tr>
  <tr>
-  <td>Art&#699;ur</td>
+  <td>Arthur</td>
   <td>&#1329;&#1408;&#1385;&#1400;&#1410;&#1408;</td>
   <td>m</td>
-  <td>Europe, Armenia</td>
+  <td>Europe; Armenian</td>
   <td>hy</td>
  </tr>
  <tr>
   <td>Yonatan (Jonathan)</td>
   <td dir=rtl>&#1497;&#1493;&#1504;&#1514;&#1503;</td>
-  <td></td>
-  <td>West Asia, Hebrew</td>
+  <td>m</td>
+  <td>West Asia; Hebrew</td>
   <td>he</td>
  </tr>
  <tr>
-  <td>&#7841;&#7717;md</td>
+  <td>Ahmed</td>
   <td dir=rtl>&#1575;&#1581;&#1605;&#1583;</td>
-  <td></td>
-  <td></td>
+  <td>m</td>
+  <td>South Asia; Urdu</td>
   <td>ur</td>
  </tr>
  <tr>
   <td>Sindbad</td>
   <td dir=rtl>&#1587;&#1606;&#1576;&#1575;&#1583;</td>
-  <td></td>
-  <td></td>
+  <td>m</td>
+  <td>South Asia; Pashto, Sindhi</td>
   <td>ps, sd</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td dir=rtl>&#1587;&#1606;&#1583;&#1576;&#1575;&#1583;</td>
-  <td></td>
-  <td></td>
+  <td>m</td>
+  <td>West Asia; Persian</td>
   <td>fa</td>
  </tr>
  <tr>
   <td>Munir</td>
   <td dir=rtl>&#1605;&#1606;&#1610;&#1585;</td>
   <td>m</td>
-  <td>West Asia, Arabic</td>
+  <td>West Asia; Arabic</td>
   <td>ar</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td>&#4658;&#4757;&#4707;&#4853;</td>
   <td>m</td>
-  <td>Africa, Ethiopia</td>
+  <td>Africa; Ethiopia</td>
   <td>am</td>
  </tr>
  <tr>
   <td>Raj</td>
   <td><span title=r&#257;ja>&#2352;&#2366;&#2332;</span></td>
   <td>m</td>
-  <td>South Asia, Konkani</td>
+  <td>South Asia; Konkani</td>
   <td>kok</td>
  </tr>
  <tr>
   <td>Lalita</td>
   <td>&#2354;&#2354;&#2367;&#2340;</td>
   <td>f</td>
-  <td>South Asia, India (Hindi)</td>
+  <td>South Asia, Hindi</td>
   <td>hi</td>
  </tr>
  <tr>
   <td>Sindab&#257;da</td>
   <td>&#2360;&#2367;&#2306;&#2342;&#2348;&#2366;&#2342;</td>
   <td>m</td>
-  <td>South Asia, India (Marathi)</td>
+  <td>South Asia, Marathi</td>
   <td>mr</td>
  </tr>
  <tr>
   <td>Sundara</td>
   <td>&#2360;&#2369;&#2344;&#2381;&#2342;&#2352;</td>
   <td>f</td>
-  <td>South Asia, Nepal</td>
+  <td>South Asia, Nepali</td>
   <td>ne</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td>&#2458;&#2495;&#2472;&#2509;&#2470;&#2476;&#2494;&#2470;</td>
   <td>m</td>
-  <td>South Asia, India (Assamese)</td>
+  <td>South Asia, Assamese</td>
   <td>as</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td>&#2488;&#2495;&#2472;&#2476;&#2494;&#2470;</td>
   <td>m</td>
-  <td>South Asia, India (Bengali)</td>
+  <td>South Asia, Bengali</td>
   <td>bn</td>
  </tr>
  <tr>
@@ -4656,79 +4672,80 @@ We could stand to cull the Japanese list. The notes need work.
   <td>Sinbad</td>
   <td>&#2744;&#2751;&#2728;&#2732;&#2750;&#2726;</td>
   <td>m</td>
-  <td>South Asia, India (Gujarati)</td>
+  <td>South Asia, Gujarati</td>
   <td>gu</td>
  </tr>
  <tr>
   <td>Sinbad</td>
   <td>&#2872;&#2879;&#2856;&#2860;&#2878;&#2854;&#2893;</td>
   <td>m</td>
-  <td>South Asia</td>
+  <td>South Asia; Odia</td>
   <td>or</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=r&#257;j&#275;ntira&#7753;>&#2992;&#3006;&#2972;&#3015;&#2984;&#3021;&#2980;&#3007;&#2992;&#2985;&#3021;</span></td>
-  <td></td>
-  <td>South Asia, India (Tamil)</td>
+  <td>Rajendran</td>
+  <td>&#2992;&#3006;&#2972;&#3015;&#2984;&#3021;&#2980;&#3007;&#2992;&#2985;&#3021;</td>
+  <td>m</td>
+  <td>South Asia, Tamil</td>
   <td>ta</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=r&#257;ja&#347;&#275;khar>&#3120;&#3134;&#3100;&#3126;&#3143;&#3094;&#3120;&#3149;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Rajasekhar</td>
+  <td>&#3120;&#3134;&#3100;&#3126;&#3143;&#3094;&#3120;&#3149;</td>
+  <td>m</td>
+  <td>South Asia; Telegu</td>
   <td>te</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title="sin&#8204;b&#257;d">&#3256;&#3263;&#3240;&#3277;&#8204;&#3244;&#3262;&#3238;&#3277;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#3256;&#3263;&#3240;&#3277;&#8204;&#3244;&#3262;&#3238;&#3277;</td>
+  <td>m</td>
+  <td>South Asia, Kannada</td>
   <td>kn</td>
  </tr>
  <tr>
-  <td></td>
-  <td><span title=si&#3451;b&#257;&#7693;>&#3384;&#3391;&#3451;&#3372;&#3390;&#3361;&#3405;</span></td>
-  <td></td>
-  <td>South Asia</td>
+  <td>Sinbad</td>
+  <td>&#3384;&#3391;&#3451;&#3372;&#3390;&#3361;&#3405;</td>
+  <td>m</td>
+  <td>South Asia; Malayalam</td>
   <td>ml</td>
  </tr>
  <tr>
-  <td></td>
+  <td>Sinbad</td>
   <td>&#3523;&#3538;&#3505;&#3530;&#3510;&#3537;&#3497;&#3530;</td>
-  <td></td>
-  <td>South Asia</td>
+  <td>m</td>
+  <td>South Asia; Sinhala</td>
   <td>si</td>
  </tr>
  <tr>
+  <td>Thana (?)</td>
+  <td>&#3608;&#3609;&#3634;</td>
   <td></td>
-  <td><span title=&#7789;hn&#257;>&#3608;&#3609;&#3634;</span></td>
-  <td></td>
-  <td>South-east Asia</td>
+  <td>Southeast Asia; Thai</td>
   <td>th</td>
  </tr>
  <tr>
-  <td></td>
+  <td>Sinbad</td>
   <td>&#3722;&#3764;&#3737;&#3777;&#3738;&#3732;</td>
-  <td></td>
-  <td>South Asia</td>
+  <td>m</td>
+  <td>South Asia; Lao</td>
   <td>lo</td>
  </tr>
  <tr>
-  <td></td>
+  <td>Sokha</td>
   <td>&#6047;&#6075;&#6017;&#6070;</td>
   <td></td>
-  <td>South Asia</td>
+  <td>South Asia; Khmer</td>
   <td>km</td>
  </tr>
  <tr>
   <td>Yumi</td>
   <td>&#50976;&#48120;</td>
   <td></td>
-  <td>East Asia</td>
+  <td>East Asia; Korean</td>
   <td>ko</td>
  </tr>
+ <!-- Dai Bun
  <tr>
   <td>dà wén</td>
   <td>&#22823;&#25991;</td>
@@ -4736,6 +4753,8 @@ We could stand to cull the Japanese list. The notes need work.
   <td>East Asia</td>
   <td>yue-Hans</td>
  </tr>
+ -->
+ <!-- Unihan?
  <tr>
   <td>y&#468; hàn</td>
   <td>&#23431;&#28698;</td>
@@ -4743,31 +4762,25 @@ We could stand to cull the Japanese list. The notes need work.
   <td>East Asia</td>
   <td>zh</td>
  </tr>
+ -->
  <tr>
-  <td>shèn tài láng</td>
+  <td>Shintaro</td>
   <td>&#24910;&#22826;&#37070;</td>
-  <td></td>
-  <td>East Asia</td>
+  <td>m</td>
+  <td>East Asia; Japanese</td>
   <td>ja</td>
  </tr>
  <tr>
-  <td>wén jié</td>
+  <td>Wén Jié</td>
   <td>&#25991;&#20625;</td>
   <td></td>
-  <td>East Asia</td>
+  <td>East Asia; Chinese, Yue</td>
   <td>yue, zh-Hant</td>
  </tr>
 </tbody>
 </table>
 
 <hr>
-
-<p>Inserting personal names from other cultures into English-language examples is also affected by the very different ways that names are used culturally around the world. For example, some cultures expect the use of a patronym/matronym in addition to the given name; or some cultures prefer more formal names (e.g. "<em>Herr Dürer</em>" vs. the informal "<em>Albrecht</em>").</p>
-
-<p>Chinese people almost never use their given name without also including their family name. When writing examples in Chinese, one might see something like <span lang="zh-Hans">路人甲</span> (it means Person A, using the Han "Heavenly Stem" ordinals, cf. <a href="https://www.w3.org/TR/predefined-counter-styles/#cjk-heavenly-stem">Ready-made Counter Styles</a>) rather than a "exemplar name". When examples are used, they include both the family and given name. Bear in mind that in Chinese the family name comes first, before the given name.</p>
-
-<p>In Japanese, there are complex choices related to levels of formality. A person <em>might</em> be addressed by their given name in very informal situations (<em>Hiroshi</em>), but usually will be addressed with a family name that includes (unless one is being rude) a title or suffix, such as <code>-san</code> or <code>-sama</code> (e.g. <em>Tanaka-san</em>). Other suffixes or titles are also used, such as <em>senpai</em> or <em>sensei</em> (for senior or very esteemed individuals) or <em>shi</em> (when one is unfamiliar with the person). Thus an example in English that could say <em>Suppose Hiroki wants to set up a...</em> would probably be more culturally appropriate if it read <em>Suppose Tanaka-san wants to set up a...</em></p>
-
 
 
 

--- a/index.html
+++ b/index.html
@@ -3670,11 +3670,16 @@ PCENChar ::=
 
 <p>Try to choose names that represent people from different regions around the world, rather than just a handful of names with European origins. Note that choosing names that include non-ASCII characters can help remind implementers that Unicode support and other internationalization concerns apply to their users.</p>
 
-<p>No collection of names can be completely agnostic in dealing with cultural and gender-related issues. To assist specification writers in creating more inclusive examples, this document provides a collection of names drawn from across many cultures. These names are organized approximately into regions described by the UN M.49 standard. Notice that even within these regions there are quite diverse influences and practices for the handling of personal names. The names are also divided by their cultural gender association to assist specification authors in writing examples, although many names are not specific to any particular gender.</p>
+<p>No collection of names can be completely agnostic in dealing with cultural and gender-related issues. To assist specification writers in creating more inclusive examples, this document provides a collection of names drawn from across many cultures. These names are organized approximately into regions, usually indicating country or language. Notice that even within these regions there are quite diverse influences and practices for the handling of personal names. The names are also divided by their cultural gender association to assist specification authors in writing examples, although many names are not specific to any particular gender.</p>
 
 <aside class="note">
 	<p>The purpose of this collection of names is to assist specification authors who are generally writing for an English-speaking audience. The collection consists primarily of given names and, where necessary, is transliterated into the Latin script. The names are also rendered informally (<em>"Alice"</em> rather than <em>"Ms. Jones"</em>), even though this is not how names would be used in many of these cultures. When translating specifications, adjustments should be made which are appropriate for the target audience.</p>
-	<p>When names are taken from non-Latin-script languages or cultures, the non-Latin representation is also provided as a reminder that names are in no way limited to the Latin script or for cases where you want to include a non-Latin script example. Wherever possible the names in this collection are taken from [[CLDR]]'s exemplary set of names.</p>
+	
+	<p>When names are taken from non-Latin-script languages or cultures, the non-Latin representation is also provided as a reminder that names are in no way limited to the Latin script or for cases where you want to include a non-Latin script example.</p>
+</aside>
+
+<aside class="note" title="Origin of this data">
+	<p>This list consists of two sets of names. The first set was compiled by the Internationalization Working Group. The second set are taken from Unicode's <cite>Common Locale Data Repository</cite> [[CLDR]] project, which maintains data about the presentation of personal names in different [= locales =] and cultures. In addition to the table below, this second set of names can be accessed on CLDR's <a href="https://unicode-org.github.io/cldr-staging/charts/latest/by_type/miscellaneous.person_name_formats.html#SampleName_Fields_for_Item:_givenOnly">charts page</a>. Note that these names are more frequently associated with the male gender, including a large number of variations on the name "Sinbad".</p>
 </aside>
 
 <!-- 

--- a/local.css
+++ b/local.css
@@ -409,21 +409,21 @@ table.whitespace caption {
 	font-style: italic;
 	}
 	
-#exampleNamesTable {
+.exampleNamesTable {
   border-collapse: collapse;
   width: 100%;
 }
 
-#exampleNamesTable td, #exampleNamesTable th {
+.exampleNamesTable td, #exampleNamesTable th {
   border: 1px solid #ddd;
   padding: 8px;
 }
 
-#exampleNamesTable tr:nth-child(even){background-color: #f2f2f2;}
+.exampleNamesTable tr:nth-child(even){background-color: #f2f2f2;}
 
-#exampleNamesTable tr:hover {background-color: #ddd;}
+.exampleNamesTable tr:hover {background-color: #ddd;}
 
-#exampleNamesTable th {
+.exampleNamesTable th {
   cursor: pointer;
   padding-top: 12px;
   padding-bottom: 12px;

--- a/local.css
+++ b/local.css
@@ -414,7 +414,7 @@ table.whitespace caption {
   width: 100%;
 }
 
-.exampleNamesTable td, #exampleNamesTable th {
+.exampleNamesTable td, .exampleNamesTable th {
   border: 1px solid #ddd;
   padding: 8px;
 }


### PR DESCRIPTION
Added, edited, and rearranged requirements. Added a link to the Design Principles doc.

These edits depend on additions to the glossary in a separate pull request. More work is needed here, particularly discussing when the choose `USVString` (which we don't mention) and making clear how to work with byte strings/encodings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/82.html" title="Last updated on Dec 15, 2022, 5:16 PM UTC (ff699d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/82/4644204...aphillips:ff699d7.html" title="Last updated on Dec 15, 2022, 5:16 PM UTC (ff699d7)">Diff</a>