### PR TITLE
Add Unicode deprecated characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -2640,8 +2640,6 @@ just as characters are the basic unit of organization of encoded text.</p>
 		<li><span class="codepoint"><span>\</span> [<span class="uname">U+005C REVERSE SOLIDUS</span>]</span></li>
 		<li><span class="codepoint"><span>|</span> [<span class="uname">U+007C VERTICAL LINE</span>]</span></li>
 		<li><span class="codepoint"><span class="uname">U+007F DEL</span></span></li>
-		<li><span class="codepoint"><span class="uname">U+E0001 LANGUAGE TAG</span></span></li>
-		<li><span class="codepoint"><span class="uname">U+E007F CANCEL TAG</span></span></li>
 		<li>Codepoints in the following ranges:
 		   <ul>
 			   <li>C0 Controls [<span class="uname">U+0000</span>...<span class="uname">U+001F</span>]</li>
@@ -2660,6 +2658,8 @@ just as characters are the basic unit of organization of encoded text.</p>
 			<li>The last two code points of the Basic Multilingual Plane (U+FFFE and U+FFFF)</li>
 			<li>The last two code points at the end of the Supplementary Planes (U+1FFFE, U+1FFFF … U+EFFFE, U+EFFFF)</li>
 		</ul></li>
+
+		<li>All Unicode <a href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">deprecated characters</a>.</li>
 
 	</ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -2659,7 +2659,7 @@ just as characters are the basic unit of organization of encoded text.</p>
 			<li>The last two code points at the end of the Supplementary Planes (U+1FFFE, U+1FFFF … U+EFFFE, U+EFFFF)</li>
 		</ul></li>
 
-		<li>All Unicode <a href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">deprecated characters</a>.</li>
+		<li>All Unicode <a href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">deprecated characters</a> (search for "Deprecated" in the page).</li>
 
 	</ul>
 </div>


### PR DESCRIPTION
To sync with https://github.com/w3c/epub-specs/pull/2476/files


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/85.html" title="Last updated on Dec 10, 2022, 6:06 AM UTC (b950935)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/85/4644204...b950935.html" title="Last updated on Dec 10, 2022, 6:06 AM UTC (b950935)">Diff</a>