### PR TITLE
Make local.css consistent with other i18n specs

### DIFF
--- a/echidna
+++ b/echidna
@@ -1,4 +1,3 @@
 # ECHIDNA configuration
 index.html?specStatus=DNOTE&shortName=international-specs respec
-local.css
 make_checklist.js

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
+	<meta charset="utf-8"/>
     <title>Internationalization Best Practices for Spec Developers</title>
-    <meta charset="utf-8"/>
-    <!-- <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet"> -->
+
     <script src="make_checklist.js"></script>
     <!--
       === NOTA BENE ===
@@ -40,7 +40,8 @@
       };
       
     </script>
-	<link rel="stylesheet" href="local.css">
+    <!-- local styles for this document -->
+	<style data-include="https://w3c.github.io/bp-i18n-specdev/local.css"></style>
   
   <script>// check for changed fragment ids and route to the new id
   var fragid = location.hash


### PR DESCRIPTION
- load local.css using data-include
- remove local.css from echidna manifest
- also move charset to the first position in head


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/94.html" title="Last updated on Apr 27, 2023, 7:09 AM UTC (5e03183)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/94/c6a83e4...aphillips:5e03183.html" title="Last updated on Apr 27, 2023, 7:09 AM UTC (5e03183)">Diff</a>