### PR TITLE
Add a section about when/how to write I18N Considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,32 @@
 <li>Ensure that your GitHub issue has the i18n-tracker label set, so that the Internationalization WG is aware of your review results.</li>
 </ol>
 </section>
+
+<section id="I18N_Considerations">
+<h3>When and how to write an <em>Internationalization Considerations</em> section in your spec</h3>
+
+<p class="advisement">All additions of or changes to an <cite>Internationalization Considerations</cite> section MUST be reviewed by the Internationalization (i18n) WG.</p>
+
+<p>Specifications are not required to include a special section or appendix describing internationalization considerations of their specification. In general, the Internationalization (i18n) WG prefers that information about language, regional, or cultural variation, support, or adaptation appear in the body of the specification, closely associated with the relevant features.</p>
+
+<p>However, there are a few cases in which you should consider providing a section like this. You should consider including an internationalization considerations section when:
+<ul>
+	<li>International features require additional explanation that would otherwise interfere with or clutter-up the body of the specification.</li>
+	<li>You wish to provide examples of features, such as localization, without interfering with the body of the specification.</li>
+	<li>There are specific limitations or problems that your specification is unable to address, such as (but not limited to) technology that is evolving but not yet ready for inclusion; limitations discovered during the horizontal review process that you intend to address in future versions; or deliberate design decisions that limit or impact certain groups or cultures.</li>
+	<li>You have other information you wish to provide to adopters or implementers that doesn't fit with the remainder of your spec.</li>
+</ul></p>
+
+<p>If you decide to create an internationalization considerations section, you should do the following:</p>
+<ol>
+	<li>Raise an issue in your specification's github repo with the title <cite>Internationalization Considerations</cite> and apply the label <code>i18n-needs-resolution</code>. This will alert the I18N WG of your intention to write a section that requires review. (This also automatically creates a tracking issue in the I18N WG's repo.)</li>
+	<li>Mention the issue in any pull request that adds or modifies the section.</li>
+	<li>Mention the issue in your horizontal review request to the I18N WG.</li>
+</ol>
+
+<p>Your internationalization considerations section should have the title <cite>Internationalization Considerations</cite> or <cite>Internationalization (I18N) Considerations</cite>. It normally should appear as an appendix in your specification. The order relative to other appendices is up to you.</p>
+
+</section>
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -179,19 +179,19 @@
 <p>However, there are a few cases in which you should consider providing a section like this. You should consider including an internationalization considerations section when:
 <ul>
 	<li>International features require additional explanation that would otherwise interfere with or clutter-up the body of the specification.</li>
-	<li>You wish to provide examples of features, such as localization, without interfering with the body of the specification.</li>
+	<li>You wish to provide examples of features, such as localization, without interfering with the body of the specification. For example, summaries of the general approach taken, or factors that affect the approach taken throughout the document.</li>
 	<li>There are specific limitations or problems that your specification is unable to address, such as (but not limited to) technology that is evolving but not yet ready for inclusion; limitations discovered during the horizontal review process that you intend to address in future versions; or deliberate design decisions that limit or impact certain groups or cultures.</li>
 	<li>You have other information you wish to provide to adopters or implementers that doesn't fit with the remainder of your spec.</li>
 </ul></p>
 
 <p>If you decide to create an internationalization considerations section, you should do the following:</p>
 <ol>
-	<li>Raise an issue in your specification's github repo with the title <cite>Internationalization Considerations</cite> and apply the label <code>i18n-needs-resolution</code>. This will alert the I18N WG of your intention to write a section that requires review. (This also automatically creates a tracking issue in the I18N WG's repo.)</li>
+	<li>Raise an issue in your specification's github repo with the title <cite>Internationalization Considerations</cite> and apply the label <code>i18n-needs-resolution</code>. This will alert the Internationalization WG of your intention to write a section that requires review. (This also automatically creates a tracking issue in the Internationalization WG's repo.)</li>
 	<li>Mention the issue in any pull request that adds or modifies the section.</li>
 	<li>Mention the issue in your horizontal review request to the I18N WG.</li>
 </ol>
 
-<p>Your internationalization considerations section should have the title <cite>Internationalization Considerations</cite> or <cite>Internationalization (I18N) Considerations</cite>. It normally should appear as an appendix in your specification. The order relative to other appendices is up to you.</p>
+<p>Your internationalization considerations section should have the title <cite>Internationalization Considerations</cite> or <cite>Internationalization (i18n) Considerations</cite>. It normally should appear as an appendix in your specification. The order relative to other appendices is up to you.</p>
 
 </section>
 </section>

--- a/index.html
+++ b/index.html
@@ -174,24 +174,21 @@
 
 <p class="advisement">All additions of or changes to an <cite>Internationalization Considerations</cite> section MUST be reviewed by the Internationalization (i18n) WG.</p>
 
-<p>Specifications are not required to include a special section or appendix describing internationalization considerations of their specification. In general, the Internationalization (i18n) WG prefers that information about language, regional, or cultural variation, support, or adaptation appear in the body of the specification, closely associated with the relevant features.</p>
+<p class="advisement">If you create an internationalization considerations section, it MUST have the title <cite>Internationalization Considerations</cite> or <cite>Internationalization (i18n) Considerations</cite>.</p>
 
-<p>However, there are a few cases in which you should consider providing a section like this. You should consider including an internationalization considerations section when:
+<p>Specifications are not required to include a special section or appendix describing internationalization considerations of their specification. In general, the Internationalization WG instead prefers that information about language, regional, or cultural variation, support, or adaptation appear in the body of the specification, closely associated with the relevant features.</p>
+
+<p>However, there are a few cases in which you might consider providing a section like this. Consider including an internationalization considerations section when:
 <ul>
 	<li>International features require additional explanation that would otherwise interfere with or clutter-up the body of the specification.</li>
 	<li>You wish to provide examples of features, such as localization, without interfering with the body of the specification. For example, summaries of the general approach taken, or factors that affect the approach taken throughout the document.</li>
-	<li>There are specific limitations or problems that your specification is unable to address, such as (but not limited to) technology that is evolving but not yet ready for inclusion; limitations discovered during the horizontal review process that you intend to address in future versions; or deliberate design decisions that limit or impact certain groups or cultures.</li>
+	<li>There are specific limitations or problems that your specification is unable to address, such as (but not limited to) technology that is evolving but not yet ready for inclusion; limitations discovered during the horizontal review process that you intend to address in future versions; or deliberate design decisions that limit or impact certain languages, groups, or cultures.</li>
 	<li>You have other information you wish to provide to adopters or implementers that doesn't fit with the remainder of your spec.</li>
 </ul></p>
 
-<p>If you decide to create an internationalization considerations section, you should do the following:</p>
-<ol>
-	<li>Raise an issue in your specification's github repo with the title <cite>Internationalization Considerations</cite> and apply the label <code>i18n-needs-resolution</code>. This will alert the Internationalization WG of your intention to write a section that requires review. (This also automatically creates a tracking issue in the Internationalization WG's repo.)</li>
-	<li>Mention the issue in any pull request that adds or modifies the section.</li>
-	<li>Mention the issue in your horizontal review request to the I18N WG.</li>
-</ol>
+<p>If you decide to create an Internationalization Considerations section, it will usually be as an appendix. However, the order and placement relative to other parts of your spec or to other appendices is up to you.</p>
 
-<p>Your internationalization considerations section should have the title <cite>Internationalization Considerations</cite> or <cite>Internationalization (i18n) Considerations</cite>. It normally should appear as an appendix in your specification. The order relative to other appendices is up to you.</p>
+<p>If you decide to create an Internationalization Considerations section, you need to mention it in your horizontal review request to the Internationalization WG. The review request template includes a checkbox which allows you to do this easily.</p>
 
 </section>
 </section>


### PR DESCRIPTION
Addresses w3c/i18n-actions#19

Adds a subsection to the Introduction dealing with how and when to write an internationalization considerations section. The specific details need to be reviewed by the WG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/112.html" title="Last updated on Jul 27, 2023, 3:27 PM UTC (560af40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/112/8037702...aphillips:560af40.html" title="Last updated on Jul 27, 2023, 3:27 PM UTC (560af40)">Diff</a>