### PR TITLE
Add requirement for character encoding in trunction

### DIFF
--- a/index.html
+++ b/index.html
@@ -2969,7 +2969,7 @@ just as characters are the basic unit of organization of encoded text.</p>
     	</div>
 
 	<div class="req" id="char_trunc_grapheme_boundary">
-	<p class="advisement">Specifications that limit the length of a string SHOULD require truncation on grapheme boundaries, as truncation in the midst of a combining or joining sequence can alter the meaning of the string.</p>
+	<p class="advisement">Specifications that limit the length of a string SHOULD require truncation on grapheme boundaries, as truncation in the midst of a <a>grapheme</a> or <a>combining character sequence</a> can alter the meaning of the string.</p>
 	</div>
 
 	<div class="req" id="char_trunc_indicator">
@@ -2977,8 +2977,14 @@ just as characters are the basic unit of organization of encoded text.</p>
 	</div>
 
 	<div class="req" id="char_trunc_min_size">
-	<p class="advisement">When specifying a length limitation in code units (such as bytes), specifications SHOULD set the maximum length in a way that accommodates users whose language requires multibyte code unit sequences.</p>
+	<p class="advisement">When specifying a length limitation in code units (such as bytes), specifications SHOULD set the limit in a way that accommodates users whose language requires multibyte code unit sequences.</p>
 	</div>
+	
+	<div class="req" id="char_trunc_character_encoding">
+		<p class="advisement">If a specification specifies a length limit in code units (such as bytes), it MUST specify the <a>character encoding</a> used in measuring the limit; such a limit SHOULD NOT specify a <a>legacy character encoding</a>.</p>
+	</div>
+	
+	<p>If a specification permits or requires truncation of a field, the <a>character encoding</a> is important in knowing what the limit means. If the limit is in bytes and <a>legacy character encodings</a> are permitted, note that conversion of Unicode data to a non-Unicode encoding can also result in data loss (since most <a>legacy character encodings</a> encode only a subset of Unicode).</p>
 </section>
 
 <section id="strcat" class="subtopic">


### PR DESCRIPTION
Addresses #124
Addresses w3c/i18n-actions#62

- Add a requirement with explanation such that byte length truncation needs to specify a character encoding (and that legacy encodings should be avoided)
- Add links to glossary terms in this section in some places
- Small tweaks to other text


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/125.html" title="Last updated on Dec 14, 2023, 4:51 PM UTC (ee3539a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/125/2a0691f...aphillips:ee3539a.html" title="Last updated on Dec 14, 2023, 4:51 PM UTC (ee3539a)">Diff</a>