### PR TITLE
Add a new guideline about ruby markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3738,6 +3738,7 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <p class="links_title">Useful background and overviews for this section</p>
 <ul>
 <li class="w3"><p class="link"><a href="https://www.w3.org/International/questions/qa-ruby">What is ruby?</a>, W3C article.</p></li>
+<li class="w3"><p class="link"><a href="https://www.w3.org/International/articles/ruby/markup.en.html">Ruby Markup</a>, W3C article.</p></li>
 <li class="w3"><p class="link"><a href="https://www.w3.org/TR/typography/#inline_notes">Inline notes & annotations</a>, in the Language enablement index.</p></li>
 </ul>
 </aside>
@@ -3762,6 +3763,9 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
    	<div class="req" id="ruby_dblsided">
 	<p class="advisement">Ruby implementations should allow annotations to appear on either or both sides of the base text.</p>
+	</div>
+	<div class="req" id="ruby_cjk">
+	<p class="advisement">Ruby markup in HTML is designed specifically for Chinese, Japanese, Korean, and Mongolian requirements, and should not be used as a general glossing mechanism.</p>
 	</div>
 </section>
 


### PR DESCRIPTION
Fix #98.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/133.html" title="Last updated on Apr 28, 2024, 5:37 AM UTC (f610a3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/133/b9a9623...f610a3c.html" title="Last updated on Apr 28, 2024, 5:37 AM UTC (f610a3c)">Diff</a>