### PR TITLE
Fix duplicate ID `links_cursive`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3661,7 +3661,7 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <h3>RTL/bidi text</h3>
 
 <p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Atyp_bidi_x" target="_blank">See related review comments.</a></p>
-<aside class="links" id="links_cursive">
+<aside class="links" id="links_bidi_text">
 <p class="links_title">Useful background and overviews for this section</p>
 <ul>
 <li class="w3"><p class="link"><a href="https://www.w3.org/TR/typography/#bidi_text">Bidirectional text</a>, in the Language enablement index.</p></li>


### PR DESCRIPTION
Fix an error spotted by specberus.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/139.html" title="Last updated on Oct 17, 2024, 3:27 PM UTC (7b955dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/139/6a5f35a...aphillips:7b955dc.html" title="Last updated on Oct 17, 2024, 3:27 PM UTC (7b955dc)">Diff</a>