### PR TITLE
Add some links to the glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,7 +527,7 @@
 
 <p class="note">The information in this section is being developed in <a href="https://www.w3.org/TR/string-meta/">Requirements for Language and Direction Metadata in Data Formats</a> [[STRING-META]]. That document is still being written, so these guidelines are likely to change at any time.</p>
 
-<p>The exchange of data on the Web, to the degree possible, should use <a>locale-neutral</a> standardized formats. However, some data on the Web necessarily consists of <a>natural language</a> information intended for display to humans. This <a>natural language</a> information depends on and benefits from the presence of language and direction metadata for proper display. Along with support for Unicode, mechanisms for including and specifying the base direction and the natural language of spans of text are one of the key internationalization considerations when developing new formats and technologies for the Web.</p>
+<p>The exchange of data on the Web, to the degree possible, should use <a>locale-neutral</a> standardized formats. However, some data on the Web necessarily consists of <a>natural language</a> information intended for display to humans. This <a>natural language</a> information depends on and benefits from the presence of language and direction metadata for proper display. Along with support for Unicode, mechanisms for including and specifying the [=base direction=] and the natural language of spans of text are one of the key internationalization considerations when developing new formats and technologies for the Web.</p>
 
 <p>The most basic best practice, which the Internationalization Working Group looks for in every specification, is:</p>
 
@@ -715,7 +715,7 @@
 
 
 	<div class="req" id="dir_paragraphs">
-	<p class="advisement">It must be possible to indicate base direction for each individual paragraph-level item of <a>natural language</a> text that will be read by someone.</p>
+	<p class="advisement">It must be possible to indicate [=base direction=] for each individual paragraph-level item of <a>natural language</a> text that will be read by someone.</p>
 	</div>
 	
 	<p>A special case of the above applies to [=natural language=] string values in data structures and document formats:</p>


### PR DESCRIPTION
For 'base direction'.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/144.html" title="Last updated on Oct 22, 2024, 1:59 PM UTC (6e33d5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/144/f429a32...6e33d5e.html" title="Last updated on Oct 22, 2024, 1:59 PM UTC (6e33d5e)">Diff</a>