### PR TITLE
Allow Ruby use in non-CJKM languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3794,7 +3794,7 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 	<p class="advisement">Ruby implementations should allow annotations to appear on either or both sides of the base text.</p>
 	</div>
 	<div class="req" id="ruby_cjk">
-	<p class="advisement">Ruby markup in HTML is designed primarily for Chinese, <a data-cite="jlreq#usage_of_ruby">Japanese</a>, Korean, and Mongolian requirements, and the needs of those languages should be prioritized in any use of the Ruby elements in other specifications. Within that constraint, Ruby may be used to associate pronunciations or meanings with a base string of text.</p>
+	<p class="advisement">Ruby markup in HTML is designed primarily for Chinese, <a data-cite="jlreq#usage_of_ruby">Japanese</a>, Korean, and Mongolian requirements, and the needs of those languages should be prioritized in any use of the Ruby elements in other specifications. Within that constraint, Ruby may be used to associate annotations with a base string of text.</p>
 	</div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -3794,7 +3794,7 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 	<p class="advisement">Ruby implementations should allow annotations to appear on either or both sides of the base text.</p>
 	</div>
 	<div class="req" id="ruby_cjk">
-	<p class="advisement">Ruby markup in HTML is designed specifically for Chinese, Japanese, Korean, and Mongolian requirements, and should not be used as a general glossing mechanism.</p>
+	<p class="advisement">Ruby markup in HTML is designed primarily for Chinese, <a data-cite="jlreq#usage_of_ruby">Japanese</a>, Korean, and Mongolian requirements, and the needs of those languages should be prioritized in any use of the Ruby elements in other specifications. Within that constraint, Ruby may be used to associate pronunciations or meanings with a base string of text.</p>
 	</div>
 </section>
 


### PR DESCRIPTION
Based on the range of Japanese semantics for Ruby that are described in https://github.com/w3c/ruby-t2s-req/issues/34, it doesn't make sense to say that Ruby is specifically useful for only 4 languages. If other specifications have a need within that range of semantics, they should reach for Ruby instead of inventing their own elements.

It wasn't clear to me what the difference is between a "general" glossing mechanism and the kinds of glosses that are in active use in Japanese, but if there is a distinction I'm missing, which needs to constrain uses in other specs, I'd be fine describing it here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/bp-i18n-specdev/pull/145.html" title="Last updated on Oct 23, 2024, 5:20 PM UTC (be31052)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/145/f429a32...jyasskin:be31052.html" title="Last updated on Oct 23, 2024, 5:20 PM UTC (be31052)">Diff</a>