### PR TITLE
Modernize 'choosing character encodings'

### DIFF
--- a/index.html
+++ b/index.html
@@ -2020,7 +2020,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
     <p>UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
-        <p>Web APIs and text processing usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because the conversion between these forms and UTF-8 is algorithmic, lossless, and usually invisible to users and since UTF-16 is a comparatively poor choice for serialization, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
+        <p>Web APIs and text processing usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because UTF-16 is a comparatively poor choice for serialization, and since the implicit conversion between UTF-8 and the various string representations is mostly invisible to users, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
     </aside>
 
     <div class="req" id="char-only-utf8">

--- a/index.html
+++ b/index.html
@@ -2020,7 +2020,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
     <p>UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
-        <p>Web APIs and text processing are usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because UTF-16 is a comparatively poor choice for serialization, and since the implicit conversion between UTF-8 and the various string representations is mostly invisible to users, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
+        <p>Web APIs and text processing are usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). UTF-16 is a comparatively poor choice for serialization. Since the implicit conversion between UTF-8 and the various string representations is mostly invisible to users, UTF-8 is therefore the preferred [=character encoding=] for storage and transmission.</p>
     </aside>
 
     <div class="req" id="char-only-utf8">

--- a/index.html
+++ b/index.html
@@ -2013,6 +2013,8 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </ul>
 </aside>
 
+    <p>Historically (and especially in the period before Unicode was created), there were many [=coded character sets=] in common use, with different schemes for encoding and serializing characters into the memory or storage of computer systems. In addition to standards-based schemes, such as those specified by ISO/IEC 8859, there were also many proprietary vendor or platform-specific [=character sets=], often with associated [=character encoding forms=]. When referring to the [=character encoding form=] of legacy (non-Unicode) [=coded character sets=] in this document, we mean the specific modern mappings of bytes to Unicode code points, as specified in [[Encoding]].</p>
+
     <div class="req" id="char-use-utf8">
         <p class="advisement">Use UTF-8 for all document formats, protocols, and serialization forms.</p>
     </div>
@@ -2098,6 +2100,8 @@ Content-Disposition: attachment; filename="Åsa.txt"
     <div class="req" id="char_enc_rules">
 	    <p class="advisement">If a specification is based on a format that permits [=character encodings=] other than UTF-8, the specification SHOULD restrict the [=character encoding=] to UTF-8.</p>
 	</div>
+    
+    <p>Document formats or protocols sometimes provide support for [=legacy character encodings=]. Specifications built upon those formats, where it is feasible to do so, can specify that conformant implementations use only UTF-8.</p>
 
  	<div class="req" id="char_heuristics">
 	<p class="advisement">Specifications MUST NOT propose the use of heuristics to determine the encoding of data.</p>

--- a/index.html
+++ b/index.html
@@ -2014,10 +2014,10 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </aside>
 
     <div class="req" id="char-use-utf8">
-        <p class="advisement">Specify UTF-8 for all document formats, protocols, or serialization forms unless you have a good reason not to.</p>
+        <p class="advisement">Use UTF-8 for all document formats, protocols, or serialization forms.</p>
     </div>
     
-    <p>When specifying the serialization of text, whether it be in a file, format, or protocol, UTF-8 is the best choice for nearly all applications.</p>
+    <p>UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
         <p>Web APIs and text processing usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because the conversion between these forms and UTF-8 is algorithmic, lossless, and usually invisible to users and since UTF-16 is a comparatively poor choice for serialization, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
@@ -2029,33 +2029,8 @@ Content-Disposition: attachment; filename="Åsa.txt"
     
     <p>New protocols and formats, as well as existing formats deployed in new contexts, are required to use the UTF-8 character encoding. This policy applies to IETF and Web standards and is articulated in [[RFC2277]], [[RFC3629]], [[Encoding]], [[design-principles]], and many more. The only specifications that need <a>legacy character encodings</a> are those that work with older protocols or formats and even there UTF-8 is strongly recommended.</p>
     
-    <div class="req" id="char_identification">
-        <p class="advisement">Specifications that allow multiple [=character encoding forms=] MUST provide character encoding identification mechanisms such that the encoding of text can be reliably identified.</p>
-	    <details class="links"><summary>explanations &amp; examples</summary>
-	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C015</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	    </details>
-    </div>
-
-	<div class="req" id="char_enc_rules">
-	    <p class="advisement">When basing a protocol, format, or API on a protocol, format, or API that already has rules for choosing, applying, or labeling the character encoding, specifications SHOULD use the existing rules rather than change these rules.</p>
-	    <details class="links"><summary>explanations &amp; examples</summary>
-	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	    </details>
-	</div>
-    
-    <p class="issue">The above needs more work to incorporate the guidance to use UTF-8 when the protocol/format is used in a new context.</p>
-	
- 	<div class="req" id="char_charset">
-	    <p class="advisement">Specifications SHOULD avoid using the terms 'character set' and 'charset' to refer to a character encoding, except when the latter is used to refer to the MIME charset parameter or its IANA-registered values. The terms [=character encoding=] or [=character encoding form=] are RECOMMENDED.</p>
-	    <details class="links"><summary>explanations &amp; examples</summary>
-	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Mandating a unique character encoding, C020</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	    </details>
-	</div>
-    
-    <p class="issue">Is the above MUSTard needed?</p>
-    
     <div class="req" id="char-use-encoding-std">
-        <p class="advisement">If a specification permits [=legacy character encodings=], it <del>SHOULD</del>MUST restrict the set of [=character encodings=] to those listed in the [[[Encoding]]] in the section "Names and Labels". Other encodings SHOULD NOT be used, except by private agreement.</p>
+        <p class="advisement">If, for historical reasons, a specification permits [=legacy character encodings=], it MUST restrict the set of [=character encodings=] to those listed in the [[[Encoding]]] in the section "Names and Labels". Other encodings SHOULD NOT be used, except by private agreement.</p>
 	    <details class="links"><summary>explanations &amp; examples</summary>
 	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C021</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
     	    <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C022</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
@@ -2079,6 +2054,50 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </ul>
 </aside>
 
+    <div class="req" id="char_identification">
+        <p class="advisement">Specifications that allow multiple [=character encoding forms=] MUST provide a mechanism, such as a field or parameter, that clearly identifies the encoding of text.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C015</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
+    </div>
+
+    <p>[=Character encodings=] cannot be reliably detected just from the byte values. If encodings other than UTF-8 are permitted, there has to be some mechanism for the [=consumer=] to determine what the encoding is.</p>
+    
+    <aside class="example" title="Examples of character encoding mechanisms">
+        <p>Here are a few examples of ways that some common specifications indicate encoding:</p>
+        <table>
+            <tr>
+                <th>Format</th><th>Example</th><th>Note</th>
+            </tr>
+            <tr>
+                <td>XML</td>
+                <td><code class="xml" style="color:gray">&lt;?xml version="1.0" <strong style="color:blue">encoding="UTF-8"</strong> ?&gt;</code></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>HTML</td>
+                <td><code class="html" style="color:gray">&lt;html&gt;<br><strong style="color:blue">&lt;meta charset="UTF-8"&gt;</strong>...</code></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>MIME type=text/*</td>
+                <td><code style="color:gray">Content-Type: text/plain<strong style="color:blue">;charset=UTF-8</strong></code></td>
+                <td>New MIME types should not specify a <code>charset</code> parameter. They should always specify UTF-8 instead.</td>
+            </tr>
+        </table>
+    </aside>
+    
+    
+	<div class="req" id="char_enc_rules">
+	    <p class="advisement">If a protocol, format, or API is based on a format that already has rules for choosing, applying, or labeling the character encoding, the specification MUST NOT define a separate mechanism for identifying the encoding.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
+	</div>
+    
+    <div class="req" id="char_enc_rules">
+	    <p class="advisement">If a specification is based on a format that permits encodings other than UTF-8, the specification SHOULD restrict the encoding to UTF-8.</p>
+	</div>
 
  	<div class="req" id="char_heuristics">
 	<p class="advisement">Specifications MUST NOT propose the use of heuristics to determine the encoding of data.</p>

--- a/index.html
+++ b/index.html
@@ -2063,8 +2063,8 @@ Content-Disposition: attachment; filename="Åsa.txt"
 
     <p>[=Character encodings=] cannot be reliably detected just from the byte values. If encodings other than UTF-8 are permitted, there has to be some mechanism for the [=consumer=] to determine what the encoding is.</p>
     
-    <aside class="example" title="Examples of character encoding mechanisms">
-        <p>Here are a few examples of ways that some common specifications indicate encoding:</p>
+    <aside class="example" title="Examples of character encoding identification mechanisms">
+        <p>Here are a few examples of ways that some common specifications indicate the [=character encoding form=] used in a given document or protocol:</p>
         <table>
             <tr>
                 <th>Format</th><th>Example</th><th>Note</th>
@@ -2089,14 +2089,14 @@ Content-Disposition: attachment; filename="Åsa.txt"
     
     
 	<div class="req" id="char_enc_rules">
-	    <p class="advisement">If a protocol, format, or API is based on a format that already has rules for choosing, applying, or labeling the character encoding, the specification MUST NOT define a separate mechanism for identifying the encoding.</p>
+	    <p class="advisement">If a protocol, format, or API is based on a format that already has rules for choosing, applying, or labeling the [=character encoding=], the specification MUST NOT define a separate mechanism for identifying the [=character encoding=].</p>
 	    <details class="links"><summary>explanations &amp; examples</summary>
 	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	    </details>
 	</div>
     
     <div class="req" id="char_enc_rules">
-	    <p class="advisement">If a specification is based on a format that permits encodings other than UTF-8, the specification SHOULD restrict the encoding to UTF-8.</p>
+	    <p class="advisement">If a specification is based on a format that permits [=character encodings=] other than UTF-8, the specification SHOULD restrict the [=character encoding=] to UTF-8.</p>
 	</div>
 
  	<div class="req" id="char_heuristics">
@@ -2107,7 +2107,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
 	</div>
 
  	<div class="req" id="char_conflict">
-	<p class="advisement">Specifications MUST define conflict-resolution mechanisms (e.g. priorities) for cases where there is multiple or conflicting information about character encoding.</p>
+	<p class="advisement">Specifications MUST define conflict-resolution mechanisms (e.g. priorities) for cases where there is multiple or conflicting information about [=character encoding=].</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
 	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C028</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	</details>

--- a/index.html
+++ b/index.html
@@ -2020,8 +2020,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
     <p>When specifying the serialization of text, whether it be in a file, format, or protocol, UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
-        <p>APIs and text processing on the Web are often defined in terms of strings, rather than as byte sequences with some specific [=character encoding=]. As discussed in [[[#char_string]]], the definition of a 'string' will almost always be in terms of UTF-16 [=code units=] ({{DOMString}}) or in terms of [=Unicode code points=] ({{USVString}}). Specifying text processing in this way is more efficient than working with bytes in UTF-8. The conversion between UTF-16 for processing and UTF-8 for serialization is algorithmic and lossless.</p>
-        <p>As a result, UTF-8 is always preferred when specifying a [=character encoding form=] on the Web.</p>
+        <p>Web APIs and text processing usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because the conversion between these forms and UTF-8 is algorithmic, lossless, and usually invisible to users and since UTF-16 is a comparatively poor choice for serialization, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
     </aside>
 
     <div class="req" id="char-only-utf8">

--- a/index.html
+++ b/index.html
@@ -2024,10 +2024,10 @@ Content-Disposition: attachment; filename="Åsa.txt"
     </aside>
 
     <div class="req" id="char-only-utf8">
-        <p class="advisement">For all new formats or protocols or where a specification can safely do so, specifications SHOULD define UTF-8 as the only permitted [=character encoding form=].</p>
+        <p class="advisement">For all new formats or protocols or where a specification can safely do so, specifications MUST define UTF-8 as the only permitted [=character encoding form=].</p>
     </div>
     
-    <p>That is, specifications should avoid adding or defining support for <a>legacy character encodings</a> unless there is a specific reason to do so. New protocols and formats, as well as existing formats deployed in new contexts, are required to use the UTF-8 character encoding. This policy applies to IETF and Web standards and is articulated in [[RFC2277]], [[RFC3629]], [[Encoding]], [[design-principles]], and many more. The only specifications that need <a>legacy character encodings</a> are those that work with older protocols or formats and even there UTF-8 is strongly recommended.</p>
+    <p>New protocols and formats, as well as existing formats deployed in new contexts, are required to use the UTF-8 character encoding. This policy applies to IETF and Web standards and is articulated in [[RFC2277]], [[RFC3629]], [[Encoding]], [[design-principles]], and many more. The only specifications that need <a>legacy character encodings</a> are those that work with older protocols or formats and even there UTF-8 is strongly recommended.</p>
     
     <div class="req" id="char_identification">
         <p class="advisement">Specifications that allow multiple [=character encoding forms=] MUST provide character encoding identification mechanisms such that the encoding of text can be reliably identified.</p>
@@ -2042,31 +2042,26 @@ Content-Disposition: attachment; filename="Åsa.txt"
 	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	    </details>
 	</div>
-
+    
+    <p class="issue">The above needs more work to incorporate the guidance to use UTF-8 when the protocol/format is used in a new context.</p>
 	
  	<div class="req" id="char_charset">
-	<p class="advisement">Specifications SHOULD avoid using the terms 'character set' and 'charset' to refer to a character encoding, except when the latter is used to refer to the MIME charset parameter or its IANA-registered values. The terms [=character encoding=] or [=character encoding form=] are RECOMMENDED.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Mandating a unique character encoding, C020</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
-    
-    <div class="req" id="char-use-encoding-std">
-        <p class="advisement">If a specification permits [=legacy character encodings=], it SHOULD restrict the set of [=character encodings=] to those listed in [[[Encoding]]] [[Encoding]] in the section "Names and Labels".</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C021</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-    </div>
-
- 	<div class="req" id="char_non_iana">
-	    <p class="advisement">Character encodings that are not in the IANA registry SHOULD NOT be used, except by private agreement. In such an agreement, the convention of using 'x-' at the beginning of the name MUST be followed.</p>
+	    <p class="advisement">Specifications SHOULD avoid using the terms 'character set' and 'charset' to refer to a character encoding, except when the latter is used to refer to the MIME charset parameter or its IANA-registered values. The terms [=character encoding=] or [=character encoding form=] are RECOMMENDED.</p>
 	    <details class="links"><summary>explanations &amp; examples</summary>
-	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C022</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-    	    <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C023</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Mandating a unique character encoding, C020</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	    </details>
 	</div>
     
-    <p class="issue">We (I18N) need to decide whether to fully embrace Encoding or keep some remnants of the IANA registry stuff around.</p> 
+    <p class="issue">Is the above MUSTard needed?</p>
+    
+    <div class="req" id="char-use-encoding-std">
+        <p class="advisement">If a specification permits [=legacy character encodings=], it <del>SHOULD</del>MUST restrict the set of [=character encodings=] to those listed in the [[[Encoding]]] in the section "Names and Labels". Other encodings SHOULD NOT be used, except by private agreement.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C021</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+    	    <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C022</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+    	    <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C023</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
+    </div>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -2014,13 +2014,14 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </aside>
 
     <div class="req" id="char-use-utf8">
-        <p class="advisement">Use UTF-8 unless you have a good reason not to.</p>
+        <p class="advisement">Specify UTF-8 for all document formats, protocols, or serialization forms unless you have a good reason not to.</p>
     </div>
     
     <p>When specifying the serialization of text, whether it be in a file, format, or protocol, UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
-        <p>APIs and text processing on the Web are often defined in terms of UTF-16 [=code units=], such as with the type {{DOMString}} or in terms of [=Unicode code points=], such as with the type {{USVString}}. Specifying text processing in this way is more efficient than working with UTF-8. However, UTF-16 is rarely used as a file encoding or for serialization in protocols: UTF-8 is always preferred.</p>
+        <p>APIs and text processing on the Web are often defined in terms of strings, rather than as byte sequences with some specific [=character encoding=]. As discussed in [[[#char_string]]], the definition of a 'string' will almost always be in terms of UTF-16 [=code units=] ({{DOMString}}) or in terms of [=Unicode code points=] ({{USVString}}). Specifying text processing in this way is more efficient than working with bytes in UTF-8. The conversion between UTF-16 for processing and UTF-8 for serialization is algorithmic and lossless.</p>
+        <p>As a result, UTF-8 is always preferred when specifying a [=character encoding form=] on the Web.</p>
     </aside>
 
     <div class="req" id="char-only-utf8">

--- a/index.html
+++ b/index.html
@@ -2013,91 +2013,61 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </ul>
 </aside>
 
-    <div class="req" id="char_string_no_legacy">
-	<p class="advisement">Specifications SHOULD NOT add or define support for <a>legacy character encodings</a> unless there is a specific reason to do so.</p>
+    <div class="req" id="char-use-utf8">
+        <p class="advisement">Use UTF-8 unless you have a good reason not to.</p>
     </div>
     
-    <p>New protocols and formats, as well as existing formats deployed in new contexts, are required to use the UTF-8 character encoding. This policy applies to IETF and Web standards and is articulated in [[RFC2277]], [[RFC3629]], [[Encoding]], [[design-principles]], and many more. The only specifications that need <a>legacy character encodings</a> are those that work with older protocols or formats and even there UTF-8 is strongly recommended.</p>
+    <p>When specifying the serialization of text, whether it be in a file, format, or protocol, UTF-8 is the best choice for nearly all applications.</p>
+    
+    <aside class="note">
+        <p>APIs and text processing on the Web are often defined in terms of UTF-16 [=code units=], such as with the type {{DOMString}} or in terms of [=Unicode code points=], such as with the type {{USVString}}. Specifying text processing in this way is more efficient than working with UTF-8. However, UTF-16 is rarely used as a file encoding or for serialization in protocols: UTF-8 is always preferred.</p>
+    </aside>
 
-	<div class="req" id="char_identification">
-	<p class="advisement">Specifications MUST either specify a unique character encoding, or provide character encoding identification mechanisms such that the encoding of text can be reliably identified.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C015</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
-
-	<div class="req" id="char_unique_for_new">
-	<p class="advisement">When designing a new protocol, format or API, specifications SHOULD require a unique character encoding.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C016</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
+    <div class="req" id="char-only-utf8">
+        <p class="advisement">For all new formats or protocols or where a specification can safely do so, specifications SHOULD define UTF-8 as the only permitted [=character encoding form=].</p>
+    </div>
+    
+    <p>That is, specifications should avoid adding or defining support for <a>legacy character encodings</a> unless there is a specific reason to do so. New protocols and formats, as well as existing formats deployed in new contexts, are required to use the UTF-8 character encoding. This policy applies to IETF and Web standards and is articulated in [[RFC2277]], [[RFC3629]], [[Encoding]], [[design-principles]], and many more. The only specifications that need <a>legacy character encodings</a> are those that work with older protocols or formats and even there UTF-8 is strongly recommended.</p>
+    
+    <div class="req" id="char_identification">
+        <p class="advisement">Specifications that allow multiple [=character encoding forms=] MUST provide character encoding identification mechanisms such that the encoding of text can be reliably identified.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C015</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
+    </div>
 
 	<div class="req" id="char_enc_rules">
-	<p class="advisement">When basing a protocol, format, or API on a protocol, format, or API that already has rules for character encoding, specifications SHOULD use rather than change these rules.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
+	    <p class="advisement">When basing a protocol, format, or API on a protocol, format, or API that already has rules for choosing, applying, or labeling the character encoding, specifications SHOULD use the existing rules rather than change these rules.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-Encodings">Choice and Identification of Character Encodings, C017</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
 	</div>
 
-
-
-
-
-	<div class="req" id="char_use_utf8">
-	<p class="advisement">When a unique character encoding is required, the character encoding MUST be UTF-8, or UTF-16.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-UniqueEncoding">Mandating a unique character encoding, C018</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
-
-<p class="note">The above guideline needs further consideration: UTF-16 and UTF-32 are not recommended these days. UTF-8 is the recommended encoding.</p>
-	
-	
 	
  	<div class="req" id="char_charset">
-	<p class="advisement">Specifications SHOULD avoid using the terms 'character set' and 'charset' to refer to a character encoding, except when the latter is used to refer to the MIME charset parameter or its IANA-registered values. The term 'character encoding', or in specific cases the terms 'character encoding form' or 'character encoding scheme', are RECOMMENDED.</p>
+	<p class="advisement">Specifications SHOULD avoid using the terms 'character set' and 'charset' to refer to a character encoding, except when the latter is used to refer to the MIME charset parameter or its IANA-registered values. The terms [=character encoding=] or [=character encoding form=] are RECOMMENDED.</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
 	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Mandating a unique character encoding, C020</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	</details>
 	</div>
-
- 	<div class="req" id="char_iana">
-	<p class="advisement">If the unique encoding approach is not taken, specifications SHOULD require the use of the IANA charset registry names, and in particular the names identified in the registry as 'MIME preferred names', to designate character encodings in protocols, data formats and APIs.</p>
+    
+    <div class="req" id="char-use-encoding-std">
+        <p class="advisement">If a specification permits [=legacy character encodings=], it SHOULD restrict the set of [=character encodings=] to those listed in [[[Encoding]]] [[Encoding]] in the section "Names and Labels".</p>
 	<details class="links"><summary>explanations &amp; examples</summary>
 	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C021</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
 	</details>
-	</div>
-	
-    <p class="note">The above guideline needs further consideration: the list of character encodings recommended for Web specifications is listed in the Encoding specification.</p>
+    </div>
 
  	<div class="req" id="char_non_iana">
-	<p class="advisement">Character encodings that are not in the IANA registry SHOULD NOT be used, except by private agreement.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C022</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
+	    <p class="advisement">Character encodings that are not in the IANA registry SHOULD NOT be used, except by private agreement. In such an agreement, the convention of using 'x-' at the beginning of the name MUST be followed.</p>
+	    <details class="links"><summary>explanations &amp; examples</summary>
+	        <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C022</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+    	    <p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C023</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
+	    </details>
 	</div>
+    
+    <p class="issue">We (I18N) need to decide whether to fully embrace Encoding or keep some remnants of the IANA registry stuff around.</p> 
 
- 	<div class="req" id="char_x">
-	<p class="advisement">If an unregistered character encoding is used, the convention of using 'x-' at the beginning of the name MUST be followed.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C023</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
-
- 	<div class="req" id="char_not_unique">
-	<p class="advisement">If the unique encoding approach is not chosen, specifications MUST designate at least one of the UTF-8 and UTF-16 encoding forms of Unicode as admissible character encodings and SHOULD choose at least one of UTF-8 or UTF-16 as required encoding forms (encoding forms that MUST be supported by implementations of the specification).</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C026</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-	</div>
-
-<div class="req" id="char_default">
-	<p class="advisement">Specifications that require a default encoding MUST define either UTF-8 or UTF-16 as the default, or both if they define suitable means of distinguishing them.</p>
-	<details class="links"><summary>explanations &amp; examples</summary>
-	<p><a href="https://www.w3.org/TR/charmod/#sec-EncodingIdent">Character encoding identification, C027</a>, in <cite>Character Model for the World Wide Web: Fundamentals</cite></p>
-	</details>
-</div>
   </section>
 
 

--- a/index.html
+++ b/index.html
@@ -2082,7 +2082,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
             <tr>
                 <td>MIME type=text/*</td>
                 <td><code style="color:gray">Content-Type: text/plain<strong style="color:blue">;charset=UTF-8</strong></code></td>
-                <td>New MIME types should not specify a <code>charset</code> parameter. They should always specify UTF-8 instead.</td>
+                <td>New MIME types should not specify a <code>charset</code> parameter. They should always assume UTF-8 instead.</td>
             </tr>
         </table>
     </aside>

--- a/index.html
+++ b/index.html
@@ -2020,7 +2020,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
     <p>UTF-8 is the best choice for nearly all applications.</p>
     
     <aside class="note">
-        <p>Web APIs and text processing usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because UTF-16 is a comparatively poor choice for serialization, and since the implicit conversion between UTF-8 and the various string representations is mostly invisible to users, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
+        <p>Web APIs and text processing are usually specified using strings rather than trying to grappple with the raw byte sequences in a specific [=character encoding form=]. As noted in [[[#char_string]]], these strings are typically represented using UTF-16 [=code units=] ({{DOMString}}) or, less commonly, as Unicode [=code points=] ({{USVString}}). Because UTF-16 is a comparatively poor choice for serialization, and since the implicit conversion between UTF-8 and the various string representations is mostly invisible to users, UTF-8 is the preferred [=character encoding=] for storage and transmission.</p>
     </aside>
 
     <div class="req" id="char-only-utf8">

--- a/index.html
+++ b/index.html
@@ -2014,7 +2014,7 @@ Content-Disposition: attachment; filename="Åsa.txt"
 </aside>
 
     <div class="req" id="char-use-utf8">
-        <p class="advisement">Use UTF-8 for all document formats, protocols, or serialization forms.</p>
+        <p class="advisement">Use UTF-8 for all document formats, protocols, and serialization forms.</p>
     </div>
     
     <p>UTF-8 is the best choice for nearly all applications.</p>


### PR DESCRIPTION
This is a follow-up to the work on byte string encoding. Our recommendations should be in sync with Encoding and other guidance.

This is a first pass for discussion in the group.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/162.html" title="Last updated on Jul 3, 2025, 3:25 PM UTC (3710e7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/162/b549f5f...aphillips:3710e7c.html" title="Last updated on Jul 3, 2025, 3:25 PM UTC (3710e7c)">Diff</a>