### PR TITLE
Add info to user input section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5962,11 +5962,11 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 <p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Aloc_input_x" target="_blank">See related review comments.</a></p>
 
-<p>In some languages, text entry may involve an input method that uses a composition phase, during which users build up text before it is committed. Specifications that define user input handling need to account for this phase so that text entry is not disrupted.</p>
-
 	<div class="req" id="loc_input_composition">
 	<p class="advisement">Specifications defining how users enter text SHOULD account for input methods that use a composition phase before text is committed.</p>
 	</div>
+
+	<p>In some languages, text entry may involve an input method that uses a composition phase, during which users build up text before it is committed. Specifications that define user input handling need to account for this phase so that text entry is not disrupted.</p>
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -5958,9 +5958,15 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 
 <section id="loc_input" class="subtopic">
-<h3><em>User input (TBD)</em></h3>
+<h3>User input</h3>
 
 <p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Aloc_input_x" target="_blank">See related review comments.</a></p>
+
+<p>In some languages, text entry may involve an input method that uses a composition phase, during which users build up text before it is committed. Specifications that define user input handling need to account for this phase so that text entry is not disrupted.</p>
+
+	<div class="req" id="loc_input_composition">
+	<p class="advisement">Specifications defining how users enter text SHOULD account for input methods that use a composition phase before text is committed.</p>
+	</div>
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -5963,10 +5963,36 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Aloc_input_x" target="_blank">See related review comments.</a></p>
 
 	<div class="req" id="loc_input_composition">
-	<p class="advisement">Specifications defining how users enter text SHOULD account for input methods that use a composition phase before text is committed.</p>
+	<p class="advisement">Specifications defining text input MUST allow for input methods and other mechanisms that use text composition or where input is not direct from keystrokes.</p>
 	</div>
 
-	<p>In some languages, text entry may involve an input method that uses a composition phase, during which users build up text before it is committed. Specifications that define user input handling need to account for this phase so that text entry is not disrupted.</p>
+	<div class="req" id="loc_input_composition_restrictions">
+	<p class="advisement">Specifications that impose constraints on text input MAY restrict input methods or text composition. Use care in specifying such restrictions, as this type of requirement can prevent some languages from being input.</p>
+	</div>
+
+	<div class="req" id="loc_input_keystrokes">
+	<p class="advisement">Specifications MUST NOT assume that a character can be input from a single keystroke.</p>
+	</div>
+
+	<div class="req" id="loc_input_committed_text">
+	<p class="advisement">Specifications MUST NOT assume that committed text consists of a single code point.</p>
+	</div>
+
+	<div class="req" id="loc_input_disable_composition">
+	<p class="advisement">For applications where text composition needs to be disabled, such as some password input contexts, specifications MUST clearly define that composition is disabled.</p>
+	</div>
+
+	<div class="req" id="loc_input_implementation_composition">
+	<p class="advisement">Implementations SHOULD support input methods and text composition. Native support ("on the spot") editing is preferred.</p>
+	</div>
+
+	<div class="req" id="loc_input_uncommitted_text">
+	<p class="advisement">Specifications and implementations SHOULD avoid processing uncommitted text. Text measurement, such as length checking, SHOULD be reserved for committed text.</p>
+	</div>
+
+	<p>In some languages, text entry may involve an input method that uses a composition phase, during which users build up text before it is committed. Text can also be supplied by speech input, handwriting recognition, assistive technology, paste operations, or other mechanisms that are not direct key presses. Specifications that define user input handling need to allow these forms of input so that text entry is not disrupted or limited to only those languages that can be typed directly from a keyboard.</p>
+
+	<p>Specifications and implementations should generally process committed text rather than intermediate composition text. Processing key presses, such as key down, key up, or typed events, is valid in some circumstances, for example for command shortcuts or low-level input features, but it should not be treated as the general model for text input.</p>
 </section>
 
 


### PR DESCRIPTION
Fix #181.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/pull/182.html" title="Last updated on Apr 25, 2026, 11:08 AM UTC (cb3ec18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/182/41aa67c...cb3ec18.html" title="Last updated on Apr 25, 2026, 11:08 AM UTC (cb3ec18)">Diff</a>