### PR TITLE
Add guidelines for writing examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -6426,9 +6426,9 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 <p>Your first responsibility, of course, is to make your Specification clear and highly readable. To that end, when providing examples of data formats, APIs, and such, you'll often use English language values to help illuminate concepts. When you have room or when it doesn't interfere with readability, though, choose values (or add additional examples) that are non-ASCII, non-English, and non-provincial. This makes the Specification more relevant to global audiences while reminding implementers that they need to support these diverse audiences.</p>
 
-<aside class="links">
+<div class="xref"><span class="seealso">See also:</span>
 <p>We covered choosing and exhibiting personal names earlier here: [[[#personal_name_examples]]]</p>
-</aside>
+</div>
 
 <div class="req" id="non-ascii-examples">
     <p class="advisement">If a value (field, name, property, etc.) supports non-ASCII characters, include non-ASCII examples so that it is clear that such values are permitted and support for such values is required.</p>

--- a/index.html
+++ b/index.html
@@ -5972,19 +5972,6 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 
 
-
-<section id="loc_examples" class="subtopic">
-<h3><em>Creating examples (TBD)</em></h3>
-
-<p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Aloc_examples_x" target="_blank">See related review comments.</a></p>
-</section>
-
-
-
-
-
-
-
 <section id="loc_localization" class="subtopic">
 <h3>Localization</h3>
 
@@ -6065,6 +6052,71 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 	<p class="advisement">In a multilingual environment it must be possible for the user to receive text in the language they prefer. This may depend on implicit user preferences based on the user's system or browser setup, or on user settings explicitly negotiated with the user.</p>
 	</div>
 </section>
+</section>
+
+
+
+
+
+<section id="writing_specs" class="topic">
+<h3>Additional guidelines when writing Specifications</h3>
+
+<div id="writing_specs_checklist" class="summaryC"></div>
+
+
+
+<p>Specifications serve diverse audiences. In addition to ensuring that whatever is being specified meets the needs of global audiences, authors can help users of the specification, particularly implementers, but applying some additional best practices to their writing.</p>
+
+<section id="loc_examples" class="subtopic">
+<h3>Creating examples</h3>
+
+<p class="reviewComments"><a href="https://github.com/w3c/i18n-activity/labels/t%3Aloc_examples_x" target="_blank">See related review comments.</a></p>
+
+
+<div class="req" id="provide-diverse-examples">
+    <p class="advisement">Ensure that your examples represent your global audience, including languages, regions, cultures, time zones, and other variations appropriate to your specification.</p>
+</div>
+
+<div class="req" id="non-ascii-examples">
+    <p class="advisement">If value supports non-ASCII characters, include an appropriate number of non-ASCII values in the examples so that it is clear that such values are permitted and support for such values is required.</p>
+</div>
+
+<p>If you permit it: show it. If a field, name, or other value can contain non-ASCII data, include at least a few examples that demonstrate this. Often this can be a second or third example, rather than the primary one, so as not to interfere with readability or editing. Showing non-ASCII values reminds implementers that they need to support international values.</p>
+
+<div class="req" id="non-english-examples">
+    <p class="advisement">Where appropriate, specifications SHOULD include non-English names, values, or tokens in examples.</p>
+</div>
+
+<p></p>
+
+<p class="seealso">See also: [[[#personal_name_examples]]]</p>
+
+<div class="req" id="non-american-examples">
+    <p class="advisement">Specifications SHOULD represent diverse regions and cultures by including examples from different countries or regions. Avoid examples that are idiosyncratic to one country, such as the USA, which might not be understood by international users.</p>
+</div>
+
+<div class="req" id="use-bp-examples">
+    <p class="advisement">Where it does not interfere with clarity, follow best practices found elsewhere in this document in examples.</p>
+</div>
+
+<p>For example, always include language and direction metadata with [=natural language=] content. If an item is [=localizable text=], show how it is localized. Show direction metadata for both left-to-right and right-to-left content.</p>
+
+<div class="req" id="use-lang-in-examples">
+    <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of non-English examples.</p>
+</div>
+
+<p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around non-English examples. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].)</p>
+
+<div class="req" id="use-bidi-in-examples">
+    <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that bidirectional text examples to display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
+</div>
+
+</section>
+
+
+
+
+
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -6078,10 +6078,10 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 </div>
 
 <div class="req" id="non-ascii-examples">
-    <p class="advisement">If value supports non-ASCII characters, include an appropriate number of non-ASCII values in the examples so that it is clear that such values are permitted and support for such values is required.</p>
+    <p class="advisement">If a value (field, name, property, etc.) supports non-ASCII characters, include non-ASCII examples so that it is clear that such values are permitted and support for such values is required.</p>
 </div>
 
-<p>If you permit it: show it. If a field, name, or other value can contain non-ASCII data, include at least a few examples that demonstrate this. Often this can be a second or third example, rather than the primary one, so as not to interfere with readability or editing. Showing non-ASCII values reminds implementers that they need to support international values.</p>
+<p><strong>If you permit it: show it.</strong> If a field, name, or other value can contain non-ASCII data, include at least a few examples that demonstrate this. Often this can be a second or third example, rather than the primary one, so as not to interfere with readability or editing. Showing non-ASCII values reminds implementers that they need to support international values.</p>
 
 <div class="req" id="non-english-examples">
     <p class="advisement">Where appropriate, specifications SHOULD include non-English names, values, or tokens in examples.</p>

--- a/index.html
+++ b/index.html
@@ -6068,15 +6068,27 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <section id="writing_considerations" class="subtopic">
 <h3>Writing Considerations</h3>
 
-<div class="req" id="use-no-translate">
-    <p class="advisement">Use the HTML attribute <code translate="no">translate</code> [[ITS]] to signal to translators portions of the document (primarily keywords reserved by your specification) which text to preserve when translating your specification.</p>
+<div class="req" id="use-translate-no">
+    <p class="advisement">Use the HTML attribute <code translate="no">translate</code> [[ITS]] with a value of <code translate="no">no</code> to signal to translators portions of the document which text to preserve when translating your specification.</p>
 </div>
+
+<details class="links">
+    <summary>more</summary>
+    <p><a href="https://www.w3.org/International/questions/qa-translate-flag.en.html"></a>Using HTML's <code translate="no">translate</code> attribute</p>
+</details> 
+
+<p>The <code translate="no">translate</code> attribute, originally defined in [[[ITS]]] [[ITS]] and later added to [[HTML]], signals either non-linguistic content (such as a data value) or reserved keywords. Keywords might be part of your specifications [=syntactic content=] or might be words you are quoting from some other specificiation. Using <code translate="no">translate="no"</code> signals to the translator (including machine translations) that the text is not to be modified during the translation process.</p>
+
 
 <aside class="example" title="Use of translate attribute">
     <p>For example:</p>
     
 <pre class="html">
-    &lt;p&gt;This sentence contains a keyword &lt;code translate="no"&gt;foo&lt;/code&gt;.&lt;/p&gt;
+    &lt;p&gt;The paragraph above uses the markup &lt;code translate="no"&gt;translate="no"&lt;/code&gt;.
+       Use markup like this when presenting non-lingustic data, for example: 
+       &lt;span translate="no" lang="zxx" dir="ltr"&gt;127.0.0.1&lt;/span&gt; is the IP address 
+       of &lt;code translate="no"&gt;localhost&lt;/code&gt;
+    &lt;/p&gt;
 </pre>
 </aside>
 
@@ -6084,7 +6096,14 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
     <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of non-English examples.</p>
 </div>
 
+<details class="links">
+    <summary>more</summary>
+    <p><a href="https://www.w3.org/International/questions/qa-choosing-language-tags.en.html">Choosing a Language Tag</a></p>
+</details>
+
 <p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around non-English examples. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].)</p>
+
+<p>For non-linguistic content, use the language tag <code translate="no" lang="zxx">zxx</code> to indicate that the content does not contain [=natural language=].</p>
 
 <div class="req" id="use-bidi-in-examples">
     <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that bidirectional text examples to display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>

--- a/index.html
+++ b/index.html
@@ -6063,9 +6063,34 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 <div id="writing_specs_checklist" class="summaryC"></div>
 
+<p>Specifications serve diverse audiences. Most of the best practices in this document are focused on the technical requirements of whatever it is that your Specification is specifying. In this section, you'll find some additional best practices to apply to your writing. These will help you address a global audience more effectively by avoiding cultural biases or help implementers understand [=internationalization=] and [=localization=] requirements.</p>
 
+<section id="writing_considerations" class="subtopic">
+<h3>Writing Considerations</h3>
 
-<p>Specifications serve diverse audiences. In addition to ensuring that whatever is being specified meets the needs of global audiences, authors can help users of the specification, particularly implementers, but applying some additional best practices to their writing.</p>
+<div class="req" id="use-no-translate">
+    <p class="advisement">Use the HTML attribute <code translate="no">translate</code> [[ITS]] to signal to translators portions of the document (primarily keywords reserved by your specification) which text to preserve when translating your specification.</p>
+</div>
+
+<aside class="example" title="Use of translate attribute">
+    <p>For example:</p>
+    
+<pre class="html">
+    &lt;p&gt;This sentence contains a keyword &lt;code translate="no"&gt;foo&lt;/code&gt;.&lt;/p&gt;
+</pre>
+</aside>
+
+<div class="req" id="use-lang-in-examples">
+    <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of non-English examples.</p>
+</div>
+
+<p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around non-English examples. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].)</p>
+
+<div class="req" id="use-bidi-in-examples">
+    <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that bidirectional text examples to display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
+</div>
+
+</section>
 
 <section id="loc_examples" class="subtopic">
 <h3>Creating examples</h3>
@@ -6077,6 +6102,12 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
     <p class="advisement">Ensure that your examples represent your global audience, including languages, regions, cultures, time zones, and other variations appropriate to your specification.</p>
 </div>
 
+<p>Your first responsibility, of course, is to make your Specification clear and highly readable. To that end, when providing examples of data formats, APIs, and such, you'll often use English language values to help illuminate concepts. When you have room or when it doesn't interfere with readability, though, choose values that are non-ASCII, non-English, and non-provincial. This makes the Specification more relevant to global audiences while reminding implementers that they need to support these diverse audiences.</p>
+
+<aside class="links">
+<p>We covered choosing and exhibiting personal names earlier here: [[[#personal_name_examples]]]</p>
+</aside>
+
 <div class="req" id="non-ascii-examples">
     <p class="advisement">If a value (field, name, property, etc.) supports non-ASCII characters, include non-ASCII examples so that it is clear that such values are permitted and support for such values is required.</p>
 </div>
@@ -6084,12 +6115,9 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <p><strong>If you permit it: show it.</strong> If a field, name, or other value can contain non-ASCII data, include at least a few examples that demonstrate this. Often this can be a second or third example, rather than the primary one, so as not to interfere with readability or editing. Showing non-ASCII values reminds implementers that they need to support international values.</p>
 
 <div class="req" id="non-english-examples">
-    <p class="advisement">Where appropriate, specifications SHOULD include non-English names, values, or tokens in examples.</p>
+    <p class="advisement">Where appropriate, specifications SHOULD include non-English data in examples.</p>
 </div>
 
-<p></p>
-
-<p class="seealso">See also: [[[#personal_name_examples]]]</p>
 
 <div class="req" id="non-american-examples">
     <p class="advisement">Specifications SHOULD represent diverse regions and cultures by including examples from different countries or regions. Avoid examples that are idiosyncratic to one country, such as the USA, which might not be understood by international users.</p>
@@ -6100,16 +6128,6 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 </div>
 
 <p>For example, always include language and direction metadata with [=natural language=] content. If an item is [=localizable text=], show how it is localized. Show direction metadata for both left-to-right and right-to-left content.</p>
-
-<div class="req" id="use-lang-in-examples">
-    <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of non-English examples.</p>
-</div>
-
-<p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around non-English examples. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].)</p>
-
-<div class="req" id="use-bidi-in-examples">
-    <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that bidirectional text examples to display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
-</div>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -6068,6 +6068,39 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 <section id="writing_considerations" class="subtopic">
 <h3>Writing Considerations</h3>
 
+<div class="req" id="use-lang-in-examples">
+    <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of examples (particularly those not in the document's primary language).</p>
+</div>
+
+<details class="links">
+    <summary>more</summary>
+    <p><a href="https://www.w3.org/International/questions/qa-choosing-language-tags.en.html">Choosing a Language Tag</a></p>
+</details>
+
+<p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around examples that are not in the document's primary language. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].) For non-linguistic content, use the language tag <code translate="no" lang="zxx">zxx</code> to indicate that the content does not contain [=natural language=].</p>
+
+<aside class="example" title="Use of the 'lang' attribute">
+    <p>Here is an example of how the <code translate="no">lang</code> attribute might be used in a specification. Note that a [=language tag=] is still needed for values that are ASCII-only, not just for the names that use a non-Latin script!</p>
+<pre class="html">
+&lt;html lang="en"&gt; &lt;!-- Establishes the document language --&gt;
+...
+&lt;p&gt;We invited Terry, &lt;span lang="ru"&gt;<span lang="ru">Е́ва</span>&lt/span&gt;, &lt;span lang="es"&gt;<span lang="es">Lucas</span>&lt;/span&gt;,
+   &lt;span lang="am"&gt;<span lang="am">ገነት</span>&lt;/span&gt;, and &lt;span lang="tr"&gt;<span lang="am">Mahmut</span>&lt;/span&gt; to the party.&lt;/p&gt;
+</pre>
+</aside>
+
+<div class="req" id="use-bidi-in-examples">
+    <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that text examples display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
+</div>
+
+<details class="links">
+    <summary>more</summary>
+    <p><a href="https://www.w3.org/TR/string-meta">Strings on the Web: Language and Direction Metadata</a> [[STRING-META]]</p>
+    <p><a href="https://www.w3.org/International/articles/strings-and-bidi/index.en.html">Strings and bidi</a></p>
+    <p><a href="https://www.w3.org/International/articles/inline-bidi-markup/index.en.html">Inline markup and bidirectional text in HTML</a></p>
+    <p><a href="https://www.w3.org/International/questions/qa-bidi-source.en.html">Working with source code markup and code examples for RTL scripts</a></p>
+</details>
+
 <div class="req" id="use-translate-no">
     <p class="advisement">Use the HTML attribute <code translate="no">translate</code> [[ITS]] with a value of <code translate="no">no</code> to signal to translators portions of the document which text to preserve when translating your specification.</p>
 </div>
@@ -6092,23 +6125,6 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 </pre>
 </aside>
 
-<div class="req" id="use-lang-in-examples">
-    <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of non-English examples.</p>
-</div>
-
-<details class="links">
-    <summary>more</summary>
-    <p><a href="https://www.w3.org/International/questions/qa-choosing-language-tags.en.html">Choosing a Language Tag</a></p>
-</details>
-
-<p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around non-English examples. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].)</p>
-
-<p>For non-linguistic content, use the language tag <code translate="no" lang="zxx">zxx</code> to indicate that the content does not contain [=natural language=].</p>
-
-<div class="req" id="use-bidi-in-examples">
-    <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that bidirectional text examples to display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
-</div>
-
 </section>
 
 <section id="loc_examples" class="subtopic">
@@ -6118,10 +6134,10 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 
 <div class="req" id="provide-diverse-examples">
-    <p class="advisement">Ensure that your examples represent your global audience, including languages, regions, cultures, time zones, and other variations appropriate to your specification.</p>
+    <p class="advisement">Ensure that your examples represent your global audience, including examples that vary in language, region, time zones, and other variations appropriate to your specification.</p>
 </div>
 
-<p>Your first responsibility, of course, is to make your Specification clear and highly readable. To that end, when providing examples of data formats, APIs, and such, you'll often use English language values to help illuminate concepts. When you have room or when it doesn't interfere with readability, though, choose values that are non-ASCII, non-English, and non-provincial. This makes the Specification more relevant to global audiences while reminding implementers that they need to support these diverse audiences.</p>
+<p>Your first responsibility, of course, is to make your Specification clear and highly readable. To that end, when providing examples of data formats, APIs, and such, you'll often use English language values to help illuminate concepts. When you have room or when it doesn't interfere with readability, though, choose values (or add additional examples) that are non-ASCII, non-English, and non-provincial. This makes the Specification more relevant to global audiences while reminding implementers that they need to support these diverse audiences.</p>
 
 <aside class="links">
 <p>We covered choosing and exhibiting personal names earlier here: [[[#personal_name_examples]]]</p>

--- a/index.html
+++ b/index.html
@@ -6346,7 +6346,7 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 
 <section id="writing_specs" class="topic">
-<h3>Additional guidelines when writing Specifications</h3>
+<h3>Editorial guidelines for specification authors</h3>
 
 <div id="writing_specs_checklist" class="summaryC"></div>
 
@@ -6357,12 +6357,12 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 <div class="req" id="use-lang-in-examples">
     <p class="advisement">Use the <code>lang</code> attribute with an appropriate [=language tag=] to ensure correct font selection and rendering of examples (particularly those not in the document's primary language).</p>
-</div>
 
 <details class="links">
     <summary>more</summary>
     <p><a href="https://www.w3.org/International/questions/qa-choosing-language-tags.en.html">Choosing a Language Tag</a></p>
 </details>
+</div>
 
 <p>To ensure proper rendering, including by assistive technologies, use the HTML <code>lang</code> attribute with an appropriate language tag around examples that are not in the document's primary language. (This is one of the purposes behind inclusion of <code>lang</code> in the character reference templates in [[[#char_ref]]].) For non-linguistic content, use the language tag <code translate="no" lang="zxx">zxx</code> to indicate that the content does not contain [=natural language=].</p>
 
@@ -6378,7 +6378,6 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
 
 <div class="req" id="use-bidi-in-examples">
     <p class="advisement">Use the <code>dir</code> attribute and appropriate Unicode bidirectional formatting characters in the <em>specification's</em> markup to ensure that text examples display properly (and to ensure that they are appropriately using [=bidi isolation=]).</p>
-</div>
 
 <details class="links">
     <summary>more</summary>
@@ -6387,15 +6386,16 @@ transactionResult: [ SUCCESS, NOT_AUTHORIZED, INTERNAL_ERROR, UNKNOWN_ERROR ]
     <p><a href="https://www.w3.org/International/articles/inline-bidi-markup/index.en.html">Inline markup and bidirectional text in HTML</a></p>
     <p><a href="https://www.w3.org/International/questions/qa-bidi-source.en.html">Working with source code markup and code examples for RTL scripts</a></p>
 </details>
+</div>
 
 <div class="req" id="use-translate-no">
     <p class="advisement">Use the HTML attribute <code translate="no">translate</code> [[ITS]] with a value of <code translate="no">no</code> to signal to translators portions of the document which text to preserve when translating your specification.</p>
-</div>
 
 <details class="links">
     <summary>more</summary>
-    <p><a href="https://www.w3.org/International/questions/qa-translate-flag.en.html"></a>Using HTML's <code translate="no">translate</code> attribute</p>
-</details> 
+    <p><a href="https://www.w3.org/International/questions/qa-translate-flag.en.html">Using HTML's <code translate="no">translate</code> attribute</a></p>
+</details>
+</div> 
 
 <p>The <code translate="no">translate</code> attribute, originally defined in [[[ITS]]] [[ITS]] and later added to [[HTML]], signals either non-linguistic content (such as a data value) or reserved keywords. Keywords might be part of your specifications [=syntactic content=] or might be words you are quoting from some other specificiation. Using <code translate="no">translate="no"</code> signals to the translator (including machine translations) that the text is not to be modified during the translation process.</p>
 


### PR DESCRIPTION
In reviewing a spec, I found that we didn't have any guidelines that addressed the need for specs to include non-ASCII/non-English/non-US examples. This is a common-enough comment from us and one of the things we check for during reviews. Not having at least one best practice seems like a gap.

I filed #184 and this PR attempts to address the issue.

Related comments: https://github.com/w3c/i18n-activity/issues?q=label%3At%3Aloc_examples_x

In writing this PR, I moved the subsection from "localization" to its own section for specification authors. I was tempted to put it right at the start, so we an collect spec-only BPs early, but am reluactant to make such a change initially.

Examples should be developed.

@r12a @xfq @jsahleen


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/185.html" title="Last updated on Jul 16, 2026, 4:02 PM UTC (98fcbd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/185/5856008...aphillips:98fcbd1.html" title="Last updated on Jul 16, 2026, 4:02 PM UTC (98fcbd1)">Diff</a>