### PR TITLE
Fix formatting error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3142,16 +3142,16 @@ Content-Disposition: attachment; filename="Åsa.txt"
 
 	<div class="req" id="string_match_steps">
         <div class="advisement">
-    <p>Define string identity matching for identifiers and syntactic content using the following steps:</p>
+        <p>Define string identity matching for identifiers and syntactic content using the following steps:</p>
 
-    <ol type="a">
-      <li>Ensure the strings to be compared consist of a sequence of Unicode code points.</li>
-      <li>Expand all character escapes and includes.</li>
-      <li>If defined, perform any case-folding and Unicode normalization steps (mulitple passes may be needed).</li>
-      <li>Perform any additional matching tailoring specific to the specification.</li>
-      <li>Compare the resulting sequences of code points for identity.</li>
-    </ol>
-    </div></div>
+        <ol type="a">
+          <li>Ensure the strings to be compared consist of a sequence of Unicode code points.</li>
+          <li>Expand all character escapes and includes.</li>
+          <li>If defined, perform any case-folding and Unicode normalization steps (mulitple passes may be needed).</li>
+          <li>Perform any additional matching tailoring specific to the specification.</li>
+          <li>Compare the resulting sequences of code points for identity.</li>
+        </ol>
+        </div> <!-- advisement -->
 
 	<details class="links"><summary>explanations &amp; examples</summary>
 	<p><a href="https://www.w3.org/TR/charmod-norm/#matchingAlgorithm">The Matching Algorithm</a>, in Character Model for the World Wide Web: String Matching</p>


### PR DESCRIPTION
One of the 'explanation and example' blocks escaped from its 'req' div. This fixes it.

Looking for a quick merge. Fragment location is https://deploy-preview-186--bp-i18n-specdev.netlify.app#string_match_steps


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/bp-i18n-specdev/pull/186.html" title="Last updated on Jul 16, 2026, 4:28 PM UTC (4ad3467)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/bp-i18n-specdev/186/5856008...aphillips:4ad3467.html" title="Last updated on Jul 16, 2026, 4:28 PM UTC (4ad3467)">Diff</a>